### PR TITLE
Upload a release artifact from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Check Code style quickly by running `rustfmt` over all code
   rustfmt:
@@ -27,8 +30,39 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add wasm32-wasi
-    - run: RUSTFLAGS="-Clink-args=--import-memory" cargo build --target wasm32-wasi
+    - run: cargo build --target wasm32-wasi
+      env:
+        RUSTFLAGS: -Clink-args=--import-memory -Ctarget-feature=+bulk-memory -Clink-args=-zstack-size=0
     - run: cargo run -p verify -- ./target/wasm32-wasi/debug/wasi_snapshot_preview1.wasm
-    - run: RUSTFLAGS="-Clink-args=--import-memory" cargo build --release --target wasm32-wasi
+    - run: cargo build --release --target wasm32-wasi
+      env:
+        RUSTFLAGS: -Clink-args=--import-memory -Ctarget-feature=+bulk-memory -Clink-args=-zstack-size=0
     - run: cargo run -p verify -- ./target/wasm32-wasi/release/wasi_snapshot_preview1.wasm
     - run: cargo test -p host
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      deployments: write
+      contents: write
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update stable && rustup default stable
+    - run: rustup target add wasm32-wasi
+    - run: cargo build --target wasm32-wasi --release
+      env:
+        RUSTFLAGS: -Clink-args=--import-memory -Ctarget-feature=+bulk-memory -Clink-args=-zstack-size=0
+    - uses: actions/upload-artifact@v3
+      with:
+        name: wasi_snapshot_preview1.wasm
+        path: target/wasm32-wasi/release/wasi_snapshot_preview1.wasm
+
+    - uses: marvinpinto/action-automatic-releases@latest
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        automatic_release_tag: latest
+        prerelease: true
+        title: "Latest Build"
+        files: target/wasm32-wasi/release/wasi_snapshot_preview1.wasm

--- a/test-programs/macros/build.rs
+++ b/test-programs/macros/build.rs
@@ -16,7 +16,10 @@ fn main() {
         .current_dir("../../")
         .arg("--target=wasm32-wasi")
         .env("CARGO_TARGET_DIR", &out_dir)
-        .env("RUSTFLAGS", "-Clink-args=--import-memory")
+        .env(
+            "RUSTFLAGS",
+            "-Clink-args=--import-memory -Clink-args=-zstack-size=0",
+        )
         .env_remove("CARGO_ENCODED_RUSTFLAGS");
     let status = cmd.status().unwrap();
     assert!(status.success());


### PR DESCRIPTION
This updates CI to upload a `wasi_snapshot_preview1.wasm` release artifact from CI. One is stored per CI job in case it needs to be inspected, and additionally a github action is used to maintain a "latest" release for pushes to `main` to ensure that the latest copy of `wasi_snapshot_preview1.wasm` is available.

I haven't thought much about official releases or tags or things like that but figured that this was a good starting place at least.