### PR TITLE
Implement args_{get,sizes_get} functions

### DIFF
--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -55,3 +55,13 @@ fn run_panic(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
     println!("{:?}", r);
     Ok(())
 }
+
+fn run_args(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
+    wasi.command(
+        &mut store,
+        0 as host::Descriptor,
+        1 as host::Descriptor,
+        &["hello", "this", "", "is an argument", "with 🚩 emoji"],
+    )?;
+    Ok(())
+}

--- a/test-programs/src/bin/args.rs
+++ b/test-programs/src/bin/args.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    assert_eq!(
+        args,
+        ["hello", "this", "", "is an argument", "with 🚩 emoji"]
+    );
+}


### PR DESCRIPTION
This commit updates the implementation of `cabi_export_realloc` to
allocate from a bump-allocated-region in `State` rather than allocating
a separate page for each argument as previously done. Additionally the
argument data is now stored within `State` as well enabling a full
implementation of the `args_get` and `args_sizes_get` syscalls.