### PR TITLE
Sync wasi.wit with wasi-filesystem

### DIFF
--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -14,15 +14,6 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         todo!()
     }
 
-    fn fallocate(
-        &mut self,
-        fd: wasi_filesystem::Descriptor,
-        offset: u64,
-        len: u64,
-    ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
-    }
-
     fn datasync(
         &mut self,
         fd: wasi_filesystem::Descriptor,

--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -85,8 +85,14 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
     fn readdir(
         &mut self,
         fd: wasi_filesystem::Descriptor,
-        rewind: bool,
-    ) -> HostResult<Vec<u8>, wasi_filesystem::Errno> {
+    ) -> HostResult<wasi_filesystem::DirEntryStream, wasi_filesystem::Errno> {
+        todo!()
+    }
+
+    fn read_dir_entry(
+        &mut self,
+        stream: wasi_filesystem::DirEntryStream,
+    ) -> HostResult<wasi_filesystem::DirEntry, wasi_filesystem::Errno> {
         todo!()
     }
 

--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -233,4 +233,39 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
     ) -> HostResult<(), wasi_filesystem::Errno> {
         todo!()
     }
+
+    fn lock_shared(
+        &mut self,
+        fd: wasi_filesystem::Descriptor,
+    ) -> HostResult<(), wasi_filesystem::Errno> {
+        todo!()
+    }
+
+    fn lock_exclusive(
+        &mut self,
+        fd: wasi_filesystem::Descriptor,
+    ) -> HostResult<(), wasi_filesystem::Errno> {
+        todo!()
+    }
+
+    fn try_lock_shared(
+        &mut self,
+        fd: wasi_filesystem::Descriptor,
+    ) -> HostResult<(), wasi_filesystem::Errno> {
+        todo!()
+    }
+
+    fn try_lock_exclusive(
+        &mut self,
+        fd: wasi_filesystem::Descriptor,
+    ) -> HostResult<(), wasi_filesystem::Errno> {
+        todo!()
+    }
+
+    fn unlock(
+        &mut self,
+        fd: wasi_filesystem::Descriptor,
+    ) -> HostResult<(), wasi_filesystem::Errno> {
+        todo!()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1429,6 +1429,7 @@ impl From<wasi_filesystem::Errno> for Errno {
             wasi_filesystem::Errno::Again => ERRNO_AGAIN,
             wasi_filesystem::Errno::Already => ERRNO_ALREADY,
             wasi_filesystem::Errno::Badmsg => ERRNO_BADMSG,
+            wasi_filesystem::Errno::Badf => ERRNO_BADF,
             wasi_filesystem::Errno::Busy => ERRNO_BUSY,
             wasi_filesystem::Errno::Canceled => ERRNO_CANCELED,
             wasi_filesystem::Errno::Child => ERRNO_CHILD,

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -512,18 +512,6 @@ interface wasi-filesystem {
       advice: advice
   ) -> result<_, errno>
 
-  /// Force the allocation of space in a file.
-  ///
-  /// Note: This is similar to `posix_fallocate` in POSIX.
-  fallocate: func(
-      /// The resource to operate on.
-      fd: descriptor,
-      /// The offset at which to start the allocation.
-      offset: filesize,
-      /// The length of the area that is allocated.
-      len: filesize
-  ) -> result<_, errno>
-
   /// Synchronize the data of a file to disk.
   ///
   /// Note: This is similar to `fdatasync` in POSIX.

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -181,6 +181,10 @@ interface wasi-filesystem {
   /// A "file" descriptor. In the future, this will be replaced by handle types.
   type descriptor = u32
 
+  /// A directory entry stream. In the future, this will be replaced by an
+  /// actual stream.
+  type dir-entry-stream = u32
+
   /// Size of a range of bytes in memory.
   type size = u32
 
@@ -318,13 +322,18 @@ interface wasi-filesystem {
   }
 
   /// A directory entry.
-  record dirent {
-      /// The serial number of the file referred to by this directory entry.
-      ino: inode,
-      /// The length of the name of the directory entry.
-      namelen: size,
+  record dir-entry {
+      /// The serial number of the object referred to by this directory entry.
+      /// May be none if the inode value is not known.
+      ///
+      /// When this is none, libc implementations might do an extra `stat-at`
+      /// call to retrieve the inode number to fill their `d_ino` fields, so
+      /// implementations which can set this to a non-none value should do so.
+      ino: option<inode>,
       /// The type of the file referred to by this directory entry.
       %type: descriptor-type,
+      /// The name of the object.
+      name: string,
   }
 
   /// Error codes returned by functions.
@@ -610,25 +619,12 @@ interface wasi-filesystem {
 
   /// Read directory entries from a directory.
   ///
-  /// TODO this shouldnt be a binary interface. Instead, define the struct
-  /// and whatever of its members are required here, and then return a list
-  /// of those structs. Delete the rewind argument.
-  ///
-  /// When successful, the contents of the output buffer consist of a sequence of
-  /// directory entries. Each directory entry consists of a `dirent` object,
-  /// followed by `dirent::d_namlen` bytes holding the name of the directory
-  /// entry.
-  ///
-  /// This function fills the output buffer as much as possible, potentially
-  /// truncating the last directory entry. This allows the caller to grow its
-  /// read buffer size in case it's too small to fit a single large directory
-  /// entry, or skip the oversized directory entry.
-  readdir: func(
-      /// The resource to operate on.
-      fd: descriptor,
-      /// If true, rewind the current position to the beginning before reading.
-      rewind: bool
-  ) -> result<list<u8>, errno>
+  /// This always returns a new stream which starts at the beginning of the
+  /// directory.
+  readdir: func(fd: descriptor) -> result<dir-entry-stream, errno>
+
+  /// Read a single directory entry from a `dir-entry-stream`.
+  read-dir-entry: func(dir-stream: dir-entry-stream) -> result<dir-entry, errno>
 
   /// Move the offset of a descriptor.
   ///

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -857,6 +857,103 @@ interface wasi-filesystem {
       /// The new permissions for the directory.
       mode: mode,
   ) -> result<_, errno>
+
+  /// Request a shared advisory lock for an open file.
+  ///
+  /// This requests a *shared* lock; more than one shared lock can be held for
+  /// a file at the same time.
+  ///
+  /// If the open file has an exclusive lock, this function downgrades the lock
+  /// to a shared lock. If it has a shared lock, this function has no effect.
+  ///
+  /// This requests an *advisory* lock, meaning that the file could be accessed
+  /// by other programs that don't hold the lock.
+  ///
+  /// It is unspecified how shared locks interact with locks acquired by
+  /// non-WASI programs.
+  ///
+  /// This function blocks until the lock can be acquired.
+  ///
+  /// Not all filesystems support locking; on filesystems which don't support
+  /// locking, this function returns `errno::notsup`.
+  ///
+  /// Note: This is similar to `flock(fd, LOCK_SH)` in Unix.
+  lock-shared: func(fd: descriptor) -> result<_, errno>
+
+  /// Request an exclusive advisory lock for an open file.
+  ///
+  /// This requests an *exclusive* lock; no other locks may be held for the
+  /// file while an exclusive lock is held.
+  ///
+  /// If the open file has a shared lock and there are no exclusive locks held
+  /// for the fhile, this function upgrades the lock to an exclusive lock. If the
+  /// open file already has an exclusive lock, this function has no effect.
+  ///
+  /// This requests an *advisory* lock, meaning that the file could be accessed
+  /// by other programs that don't hold the lock.
+  ///
+  /// It is unspecified whether this function succeeds if the file descriptor
+  /// is not opened for writing. It is unspecified how exclusive locks interact
+  /// with locks acquired by non-WASI programs.
+  ///
+  /// This function blocks until the lock can be acquired.
+  ///
+  /// Not all filesystems support locking; on filesystems which don't support
+  /// locking, this function returns `errno::notsup`.
+  ///
+  /// Note: This is similar to `flock(fd, LOCK_EX)` in Unix.
+  lock-exclusive: func(fd: descriptor) -> result<_, errno>
+
+  /// Request a shared advisory lock for an open file.
+  ///
+  /// This requests a *shared* lock; more than one shared lock can be held for
+  /// a file at the same time.
+  ///
+  /// If the open file has an exclusive lock, this function downgrades the lock
+  /// to a shared lock. If it has a shared lock, this function has no effect.
+  ///
+  /// This requests an *advisory* lock, meaning that the file could be accessed
+  /// by other programs that don't hold the lock.
+  ///
+  /// It is unspecified how shared locks interact with locks acquired by
+  /// non-WASI programs.
+  ///
+  /// This function returns `errno::wouldblock` if the lock cannot be acquired.
+  ///
+  /// Not all filesystems support locking; on filesystems which don't support
+  /// locking, this function returns `errno::notsup`.
+  ///
+  /// Note: This is similar to `flock(fd, LOCK_SH | LOCK_NB)` in Unix.
+  try-lock-shared: func(fd: descriptor) -> result<_, errno>
+
+  /// Request an exclusive advisory lock for an open file.
+  ///
+  /// This requests an *exclusive* lock; no other locks may be held for the
+  /// file while an exclusive lock is held.
+  ///
+  /// If the open file has a shared lock and there are no exclusive locks held
+  /// for the fhile, this function upgrades the lock to an exclusive lock. If the
+  /// open file already has an exclusive lock, this function has no effect.
+  ///
+  /// This requests an *advisory* lock, meaning that the file could be accessed
+  /// by other programs that don't hold the lock.
+  ///
+  /// It is unspecified whether this function succeeds if the file descriptor
+  /// is not opened for writing. It is unspecified how exclusive locks interact
+  /// with locks acquired by non-WASI programs.
+  ///
+  /// This function returns `errno::wouldblock` if the lock cannot be acquired.
+  ///
+  /// Not all filesystems support locking; on filesystems which don't support
+  /// locking, this function returns `errno::notsup`.
+  ///
+  /// Note: This is similar to `flock(fd, LOCK_EX | LOCK_NB)` in Unix.
+  try-lock-exclusive: func(fd: descriptor) -> result<_, errno>
+
+  /// Release a shared or exclusive lock on an open file.
+  ///
+  /// Note: This is similar to `flock(fd, LOCK_UN)` in Unix.
+  unlock: func(fd: descriptor) -> result<_, errno>
 }
 
 /// # WASI Poll API

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -348,6 +348,8 @@ interface wasi-filesystem {
       already,
       /// Bad message.
       badmsg,
+      /// Bad descriptor.
+      badf,
       /// Device or resource busy.
       busy,
       /// Operation canceled.


### PR DESCRIPTION
This pulls in https://github.com/WebAssembly/wasi-filesystem/pull/72, https://github.com/WebAssembly/wasi-filesystem/pull/69,  https://github.com/WebAssembly/wasi-filesystem/pull/64, and https://github.com/WebAssembly/wasi-filesystem/pull/62.

This updates the `readdir` to not be based on bytes, adds file locking APIs, removes the `allocate` function, and adds a `badf` errno code, in the wit interface.