### PR TITLE
Implement the `fd_readdir` function

### DIFF
--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -92,7 +92,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
     fn read_dir_entry(
         &mut self,
         stream: wasi_filesystem::DirEntryStream,
-    ) -> HostResult<wasi_filesystem::DirEntry, wasi_filesystem::Errno> {
+    ) -> HostResult<Option<wasi_filesystem::DirEntry>, wasi_filesystem::Errno> {
         todo!()
     }
 

--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -96,6 +96,13 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         todo!()
     }
 
+    fn close_dir_entry_stream(
+        &mut self,
+        fd: wasi_filesystem::DirEntryStream,
+    ) -> anyhow::Result<()> {
+        todo!()
+    }
+
     fn seek(
         &mut self,
         fd: wasi_filesystem::Descriptor,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -724,7 +724,7 @@ pub unsafe extern "C" fn fd_readdir(
 
     impl Drop for CloseOnDrop {
         fn drop(&mut self) {
-            wasi_filesystem::close(self.0);
+            wasi_filesystem::close_dir_entry_stream(self.0);
         }
     }
 }

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -623,6 +623,9 @@ interface wasi-filesystem {
   /// directory.
   readdir: func(fd: descriptor) -> result<dir-entry-stream, errno>
 
+  /// Closes a handle returned by `readdir`
+  close-dir-entry-stream: func(s: dir-entry-stream)
+
   /// Read a single directory entry from a `dir-entry-stream`.
   read-dir-entry: func(dir-stream: dir-entry-stream) -> result<option<dir-entry>, errno>
 

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -624,7 +624,7 @@ interface wasi-filesystem {
   readdir: func(fd: descriptor) -> result<dir-entry-stream, errno>
 
   /// Read a single directory entry from a `dir-entry-stream`.
-  read-dir-entry: func(dir-stream: dir-entry-stream) -> result<dir-entry, errno>
+  read-dir-entry: func(dir-stream: dir-entry-stream) -> result<option<dir-entry>, errno>
 
   /// Move the offset of a descriptor.
   ///


### PR DESCRIPTION
This roughly matches the implementation in `wasi-common` today where it uses the directory entry stream as a form of iterator and the `cookie` represents the `n`th iteration. Not exactly efficient if the `buf` provided to the hostcall is too small to hold many of the entries but there's not a whole lot else that can be done at this time.

This also updates the WIT for `read-dir-entry` to return `option<dir-entry>` instead of `dir-entry` to indicate EOF. I'm not sure if this was an oversight or whether it was intended for an error code to indicate end-of-stream instead, happy to change to either!