### PR TITLE
Implement `getrandom` using `Standard` distribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "cap-rand",
  "cap-std",
  "test-log",
  "test-programs-macros",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 cap-std = { workspace = true }
+cap-rand = { workspace = true }
 tokio = { version = "1.22.0", features = [ "rt", "macros" ] }
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime" }
 wit-bindgen-host-wasmtime-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", features = ["tracing"] }

--- a/host/src/random.rs
+++ b/host/src/random.rs
@@ -1,9 +1,14 @@
 #![allow(unused_variables)]
+use cap_rand::{distributions::Standard, Rng};
+
 use crate::{wasi_random, WasiCtx};
 
 #[async_trait::async_trait]
 impl wasi_random::WasiRandom for WasiCtx {
     async fn getrandom(&mut self, len: u32) -> anyhow::Result<Vec<u8>> {
-        todo!()
+        Ok((&mut self.random)
+            .sample_iter(Standard)
+            .take(len as usize)
+            .collect())
     }
 }


### PR DESCRIPTION
Implements the `wasi_random::WasiRandom::getrandom` method for `WasiCtx` using the [`Standard`] distribution.

If this repo isn't open to PRs, thats fine. I just thought I'd submit a PR as a personal project depends on this, and it would allow me to remove my fork and use this repository directly.

[`Standard`]: https://docs.rs/rand/latest/rand/distributions/index.html#the-standard-distribution