### PR TITLE
Upgrade `wasmtime` and remove `wit-bindgen-host-wasmtime-rust`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,26 +218,26 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "0.92.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "0.92.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "arrayvec",
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
- "cranelift-egraph",
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
+ "hashbrown",
  "log",
  "regalloc2",
  "smallvec",
@@ -246,42 +246,29 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "0.92.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
-
-[[package]]
-name = "cranelift-egraph"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
-dependencies = [
- "cranelift-entity",
- "fxhash",
- "hashbrown",
- "indexmap",
- "log",
- "smallvec",
-]
+version = "0.92.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "0.92.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "0.92.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -291,13 +278,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "0.92.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 
 [[package]]
 name = "cranelift-native"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "0.92.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -306,8 +293,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.91.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "0.92.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -315,7 +302,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
  "wasmtime-types",
 ]
 
@@ -600,7 +587,6 @@ dependencies = [
  "wasi-cap-std-sync",
  "wasi-common",
  "wasmtime",
- "wit-bindgen-host-wasmtime-rust",
 ]
 
 [[package]]
@@ -667,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec947b7a4ce12e3b87e353abae7ce124d025b6c7d6c5aea5cc0bcf92e9510ded"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
@@ -741,9 +727,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "linux-raw-sys"
@@ -847,9 +833,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "cf1c2c742266c2f1041c914ba65355a83ae8747b05f208319784083583494b4b"
 
 [[package]]
 name = "percent-encoding"
@@ -939,11 +925,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -982,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b072c75d1b10368447a55cf1d589f2527d956e92c281c81c3e788cda81b983"
+checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
 dependencies = [
  "fxhash",
  "log",
@@ -1035,9 +1020,9 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
@@ -1057,18 +1042,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.148"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.148"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1115,9 +1100,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1321,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicase"
@@ -1492,19 +1477,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.2.44"
+name = "wasmparser"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae24500f9cc27a4b2b338e66693ff53c08b17cf920bdc81e402a09fe7a204eea"
+checksum = "adde01ade41ab9a5d10ec8ed0bb954238cf8625b5cd5a13093d6de2ad9c2be1a"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045e1aa2cac847f4f94a1e25db9f084a947aeff47d9099fb9c5ccd16d335040"
 dependencies = [
  "anyhow",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1521,7 +1516,7 @@ dependencies = [
  "rayon",
  "serde",
  "target-lexicon",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -1536,16 +1531,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "anyhow",
  "base64",
@@ -1563,24 +1558,26 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
  "wasmtime-component-util",
+ "wasmtime-wit-bindgen",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1593,14 +1590,14 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -1612,7 +1609,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "wasm-encoder 0.20.0",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -1620,8 +1617,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1632,8 +1629,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1647,7 +1644,6 @@ dependencies = [
  "rustc-demangle",
  "serde",
  "target-lexicon",
- "thiserror",
  "wasmtime-environ",
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
@@ -1657,8 +1653,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "object",
  "once_cell",
@@ -1667,8 +1663,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "3.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1677,8 +1673,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "anyhow",
  "cc",
@@ -1693,7 +1689,6 @@ dependencies = [
  "paste",
  "rand",
  "rustix",
- "thiserror",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -1703,13 +1698,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "4.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#79f7fa607994bdf68a146acae16dd83453ed709d"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.95.0",
+ "wasmparser 0.96.0",
+]
+
+[[package]]
+name = "wasmtime-wit-bindgen"
+version = "5.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+dependencies = [
+ "heck",
+ "wit-parser",
 ]
 
 [[package]]
@@ -1835,7 +1839,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#9c40084d14f50d18f1bb1c80c04e06ac50188c17"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#04da8c22848ba931a2601c6641af7d113f156b0e"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -1845,18 +1849,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-guest-rust"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#9c40084d14f50d18f1bb1c80c04e06ac50188c17"
-dependencies = [
- "heck",
- "wit-bindgen-core",
- "wit-bindgen-gen-rust-lib",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-gen-host-wasmtime-rust"
-version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#9c40084d14f50d18f1bb1c80c04e06ac50188c17"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#04da8c22848ba931a2601c6641af7d113f156b0e"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -1867,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-gen-rust-lib"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#9c40084d14f50d18f1bb1c80c04e06ac50188c17"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#04da8c22848ba931a2601c6641af7d113f156b0e"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -1876,7 +1869,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-guest-rust"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#9c40084d14f50d18f1bb1c80c04e06ac50188c17"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#04da8c22848ba931a2601c6641af7d113f156b0e"
 dependencies = [
  "bitflags",
  "wit-bindgen-guest-rust-macro",
@@ -1885,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-guest-rust-macro"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#9c40084d14f50d18f1bb1c80c04e06ac50188c17"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#04da8c22848ba931a2601c6641af7d113f156b0e"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1895,35 +1888,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-host-wasmtime-rust"
-version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#9c40084d14f50d18f1bb1c80c04e06ac50188c17"
-dependencies = [
- "anyhow",
- "async-trait",
- "bitflags",
- "tracing",
- "wasmtime",
- "wit-bindgen-host-wasmtime-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-host-wasmtime-rust-macro"
-version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#9c40084d14f50d18f1bb1c80c04e06ac50188c17"
-dependencies = [
- "proc-macro2",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-gen-host-wasmtime-rust",
- "wit-bindgen-rust-macro-shared",
- "wit-component",
-]
-
-[[package]]
 name = "wit-bindgen-rust-macro-shared"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#9c40084d14f50d18f1bb1c80c04e06ac50188c17"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#04da8c22848ba931a2601c6641af7d113f156b0e"
 dependencies = [
  "proc-macro2",
  "syn",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -10,13 +10,12 @@ async-trait = { workspace = true }
 cap-std = { workspace = true }
 cap-rand = { workspace = true }
 tokio = { version = "1.22.0", features = [ "rt", "macros" ] }
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime" }
-wit-bindgen-host-wasmtime-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", features = ["tracing"] }
+tracing = { workspace = true }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", features = ["component-model"] }
 wasi-common = { path = "../wasi-common" }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
 
 [dev-dependencies]
 test-programs-macros = { path = "../test-programs/macros" }
-tracing = { version = "0.1.26" }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt" ]}
 test-log = { version = "0.2", default-features = false, features = ["trace"] }

--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -1,18 +1,15 @@
 #![allow(unused_variables)]
 
-use crate::{wasi_filesystem, WasiCtx};
+use crate::{wasi_filesystem, HostResult, WasiCtx};
 use std::io::{IoSlice, IoSliceMut};
 use wasi_common::file::TableFileExt;
-use wit_bindgen_host_wasmtime_rust::Result as HostResult;
 
-fn convert(
-    error: wasi_common::Error,
-) -> wit_bindgen_host_wasmtime_rust::Error<wasi_filesystem::Errno> {
+fn convert(error: wasi_common::Error) -> wasmtime::component::Error<wasi_filesystem::Errno> {
     if let Some(errno) = error.downcast_ref() {
         use wasi_common::Errno::*;
         use wasi_filesystem::Errno;
 
-        wit_bindgen_host_wasmtime_rust::Error::new(match errno {
+        wasmtime::component::Error::new(match errno {
             Acces => Errno::Access,
             Addrinuse => Errno::Addrinuse,
             Addrnotavail => Errno::Addrnotavail,
@@ -199,7 +196,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         todo!()
     }
 
-    fn close_dir_entry_stream(
+    async fn close_dir_entry_stream(
         &mut self,
         fd: wasi_filesystem::DirEntryStream,
     ) -> anyhow::Result<()> {

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -6,7 +6,9 @@ mod random;
 mod tcp;
 pub use wasi_common::{table::Table, WasiCtx};
 
-wit_bindgen_host_wasmtime_rust::generate!({
+type HostResult<T, E> = Result<T, wasmtime::component::Error<E>>;
+
+wasmtime::component::bindgen!({
     path: "../wit/wasi.wit",
     tracing: true,
     async: true,

--- a/host/src/tcp.rs
+++ b/host/src/tcp.rs
@@ -1,24 +1,17 @@
 use crate::{
     wasi_tcp::{self, BytesResult, Socket, WasiFuture, WasiTcp},
-    WasiCtx,
+    HostResult, WasiCtx,
 };
 use anyhow::Result;
-use wit_bindgen_host_wasmtime_rust::Error;
 
 #[async_trait::async_trait]
 impl WasiTcp for WasiCtx {
-    async fn bytes_readable(
-        &mut self,
-        socket: Socket,
-    ) -> Result<BytesResult, Error<wasi_tcp::Error>> {
+    async fn bytes_readable(&mut self, socket: Socket) -> HostResult<BytesResult, wasi_tcp::Error> {
         drop(socket);
         todo!()
     }
 
-    async fn bytes_writable(
-        &mut self,
-        socket: Socket,
-    ) -> Result<BytesResult, Error<wasi_tcp::Error>> {
+    async fn bytes_writable(&mut self, socket: Socket) -> HostResult<BytesResult, wasi_tcp::Error> {
         drop(socket);
         todo!()
     }


### PR DESCRIPTION
Removes `wit-bindgen-host-wasmtime-rust` and instead uses the `wasmtime::component::bindgen` macro.

This involed a few minor changes to the code, and introduced a `HostResult` type alias in the host.