### PR TITLE
Don't print extra metadata in stdout/stderr, and implement proc_exit

### DIFF
--- a/host/src/exit.rs
+++ b/host/src/exit.rs
@@ -9,6 +9,6 @@ impl wasi_exit::WasiExit for WasiCtx {
             Ok(()) => 0,
             Err(()) => 1,
         };
-        std::process::exit(status)
+        Err(anyhow::anyhow!(wasi_common::I32Exit(status)))
     }
 }

--- a/host/src/exit.rs
+++ b/host/src/exit.rs
@@ -1,0 +1,14 @@
+#![allow(unused_variables)]
+
+use crate::{wasi_exit, WasiCtx};
+
+#[async_trait::async_trait]
+impl wasi_exit::WasiExit for WasiCtx {
+    async fn exit(&mut self, status: Result<(), ()>) -> anyhow::Result<()> {
+        let status = match status {
+            Ok(()) => 0,
+            Err(()) => 1,
+        };
+        std::process::exit(status)
+    }
+}

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -1,4 +1,5 @@
 mod clocks;
+mod exit;
 mod filesystem;
 mod logging;
 mod poll;
@@ -21,9 +22,11 @@ pub fn add_to_linker<T: Send>(
     wasi_clocks::add_to_linker(l, f)?;
     wasi_default_clocks::add_to_linker(l, f)?;
     wasi_filesystem::add_to_linker(l, f)?;
-    wasi_logging::add_to_linker(l, f)?;
+    wasi_stdout::add_to_linker(l, f)?;
+    wasi_stderr::add_to_linker(l, f)?;
     wasi_poll::add_to_linker(l, f)?;
     wasi_random::add_to_linker(l, f)?;
     wasi_tcp::add_to_linker(l, f)?;
+    wasi_exit::add_to_linker(l, f)?;
     Ok(())
 }

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -22,8 +22,7 @@ pub fn add_to_linker<T: Send>(
     wasi_clocks::add_to_linker(l, f)?;
     wasi_default_clocks::add_to_linker(l, f)?;
     wasi_filesystem::add_to_linker(l, f)?;
-    wasi_stdout::add_to_linker(l, f)?;
-    wasi_stderr::add_to_linker(l, f)?;
+    wasi_logging::add_to_linker(l, f)?;
     wasi_poll::add_to_linker(l, f)?;
     wasi_random::add_to_linker(l, f)?;
     wasi_tcp::add_to_linker(l, f)?;

--- a/host/src/logging.rs
+++ b/host/src/logging.rs
@@ -1,16 +1,29 @@
 #![allow(unused_variables)]
 
-use crate::{wasi_logging, WasiCtx};
+use crate::{wasi_stderr, wasi_stdout, WasiCtx};
 
 #[async_trait::async_trait]
-impl wasi_logging::WasiLogging for WasiCtx {
+impl wasi_stdout::WasiStdout for WasiCtx {
     async fn log(
         &mut self,
-        level: wasi_logging::Level,
-        context: String,
+        _level: wasi_stdout::Level,
+        _context: String,
         message: String,
     ) -> anyhow::Result<()> {
-        println!("{:?} {}: {}", level, context, message);
+        print!("{}", message);
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl wasi_stderr::WasiStderr for WasiCtx {
+    async fn log(
+        &mut self,
+        _level: wasi_stderr::Level,
+        _context: String,
+        message: String,
+    ) -> anyhow::Result<()> {
+        eprint!("{}", message);
         Ok(())
     }
 }

--- a/host/src/logging.rs
+++ b/host/src/logging.rs
@@ -1,29 +1,16 @@
 #![allow(unused_variables)]
 
-use crate::{wasi_stderr, wasi_stdout, WasiCtx};
+use crate::{wasi_logging, WasiCtx};
 
 #[async_trait::async_trait]
-impl wasi_stdout::WasiStdout for WasiCtx {
+impl wasi_logging::WasiLogging for WasiCtx {
     async fn log(
         &mut self,
-        _level: wasi_stdout::Level,
-        _context: String,
+        level: wasi_logging::Level,
+        context: String,
         message: String,
     ) -> anyhow::Result<()> {
-        print!("{}", message);
-        Ok(())
-    }
-}
-
-#[async_trait::async_trait]
-impl wasi_stderr::WasiStderr for WasiCtx {
-    async fn log(
-        &mut self,
-        _level: wasi_stderr::Level,
-        _context: String,
-        message: String,
-    ) -> anyhow::Result<()> {
-        eprint!("{}", message);
+        println!("{:?} {}: {}", level, context, message);
         Ok(())
     }
 }

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -1036,9 +1036,8 @@ interface wasi-tcp {
 world wasi {
   import wasi-clocks: wasi-clocks
   import wasi-default-clocks: wasi-default-clocks
+  import wasi-logging: wasi-logging
   import wasi-filesystem: wasi-filesystem
-  import wasi-stdout: wasi-logging
-  import wasi-stderr: wasi-logging
   import wasi-random: wasi-random
   import wasi-poll: wasi-poll
   import wasi-tcp: wasi-tcp

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -3,6 +3,11 @@ interface command {
   command: func(stdin: descriptor, stdout: descriptor, args: list<string>)
 }
 
+interface wasi-exit {
+  /// Exit the curerent instance and any linked instances.
+  exit: func(status: result)
+}
+
 /// # WASI Clocks API
 ///
 /// WASI Clocks is a clock API intended to let users query the current time and
@@ -1031,11 +1036,13 @@ interface wasi-tcp {
 world wasi {
   import wasi-clocks: wasi-clocks
   import wasi-default-clocks: wasi-default-clocks
-  import wasi-logging: wasi-logging
   import wasi-filesystem: wasi-filesystem
+  import wasi-stdout: wasi-logging
+  import wasi-stderr: wasi-logging
   import wasi-random: wasi-random
   import wasi-poll: wasi-poll
   import wasi-tcp: wasi-tcp
+  import wasi-exit: wasi-exit
 
   default export command
 }


### PR DESCRIPTION
Import wasi-logging twice, once as stdout and once as stderr, and change the host implementation to just pass the string through to the host stdout/stderr as appropriate.

Also, add an API to implement proc_exit with, and implement it.