### PR TITLE
add tests for `wasi-random`, `wasi-clocks`, and stdin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,6 +1168,7 @@ dependencies = [
 name = "test-programs"
 version = "0.0.0"
 dependencies = [
+ "getrandom",
  "wasi",
  "wit-bindgen-guest-rust",
 ]

--- a/host/src/random.rs
+++ b/host/src/random.rs
@@ -1,4 +1,3 @@
-#![allow(unused_variables)]
 use cap_rand::{distributions::Standard, Rng};
 
 use crate::{wasi_random, WasiCtx};

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -1,6 +1,13 @@
 use anyhow::Result;
+use cap_rand::RngCore;
+use cap_std::time::{Duration, Instant, SystemTime};
 use host::{add_to_linker, Wasi, WasiCtx};
+use std::{io::Cursor, sync::Mutex};
 use wasi_cap_std_sync::WasiCtxBuilder;
+use wasi_common::{
+    clocks::{WasiMonotonicClock, WasiSystemClock},
+    pipe::ReadPipe,
+};
 use wasmtime::{
     component::{Component, Linker},
     Config, Engine, Store,
@@ -67,6 +74,102 @@ async fn run_args(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
         0 as host::Descriptor,
         1 as host::Descriptor,
         &["hello", "this", "", "is an argument", "with 🚩 emoji"],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn run_random(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
+    struct FakeRng;
+
+    impl RngCore for FakeRng {
+        fn next_u32(&mut self) -> u32 {
+            42
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            unimplemented!()
+        }
+
+        fn fill_bytes(&mut self, _dest: &mut [u8]) {
+            unimplemented!()
+        }
+
+        fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), cap_rand::Error> {
+            unimplemented!()
+        }
+    }
+
+    store.data_mut().random = Box::new(FakeRng);
+
+    wasi.command(
+        &mut store,
+        0 as host::Descriptor,
+        1 as host::Descriptor,
+        &[],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn run_time(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
+    struct FakeSystemClock;
+
+    impl WasiSystemClock for FakeSystemClock {
+        fn resolution(&self) -> Duration {
+            Duration::from_secs(1)
+        }
+
+        fn now(&self, _precision: Duration) -> SystemTime {
+            SystemTime::from_std(std::time::SystemTime::UNIX_EPOCH)
+                + Duration::from_secs(1431648000)
+        }
+    }
+
+    struct FakeMonotonicClock {
+        now: Mutex<Instant>,
+    }
+
+    impl WasiMonotonicClock for FakeMonotonicClock {
+        fn resolution(&self) -> Duration {
+            Duration::from_secs(1)
+        }
+
+        fn now(&self, _precision: Duration) -> Instant {
+            let mut now = self.now.lock().unwrap();
+            let then = *now;
+            *now += Duration::from_secs(42);
+            then
+        }
+    }
+
+    store.data_mut().clocks.system = Box::new(FakeSystemClock);
+    store.data_mut().clocks.monotonic = Box::new(FakeMonotonicClock {
+        now: Mutex::new(Instant::from_std(std::time::Instant::now())),
+    });
+
+    wasi.command(
+        &mut store,
+        0 as host::Descriptor,
+        1 as host::Descriptor,
+        &[],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn run_stdin(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
+    store
+        .data_mut()
+        .set_stdin(Box::new(ReadPipe::new(Cursor::new(
+            "So rested he by the Tumtum tree",
+        ))));
+
+    wasi.command(
+        &mut store,
+        0 as host::Descriptor,
+        1 as host::Descriptor,
+        &[],
     )
     .await?;
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1792,7 +1792,7 @@ const fn command_data_size() -> usize {
     start -= size_of::<DirentCache>();
 
     // Remove miscellaneous metadata also stored in state.
-    start -= 7 * size_of::<usize>();
+    start -= 9 * size_of::<usize>();
 
     // Everything else is the `command_data` allocation.
     start
@@ -1802,7 +1802,7 @@ const fn command_data_size() -> usize {
 // mostly guarantees that it's not larger than one page which is relied upon
 // below.
 const _: () = {
-    let _size_assert: [(); PAGE_SIZE] = [(); size_of::<State>()];
+    let _size_assert: [(); PAGE_SIZE] = [(); size_of::<RefCell<State>>()];
 };
 
 #[allow(improper_ctypes)]

--- a/test-programs/Cargo.toml
+++ b/test-programs/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
+getrandom = "0.2.8"
 wasi = "0.11"
 wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }

--- a/test-programs/src/bin/random.rs
+++ b/test-programs/src/bin/random.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let mut byte = [0_u8];
+    getrandom::getrandom(&mut byte);
+
+    assert_eq!(42, byte[0]);
+}

--- a/test-programs/src/bin/stdin.rs
+++ b/test-programs/src/bin/stdin.rs
@@ -1,0 +1,8 @@
+use std::io;
+
+fn main() {
+    assert_eq!(
+        "So rested he by the Tumtum tree",
+        &io::read_to_string(io::stdin().lock()).unwrap()
+    );
+}

--- a/test-programs/src/bin/time.rs
+++ b/test-programs/src/bin/time.rs
@@ -1,0 +1,12 @@
+use std::time::{Duration, Instant, SystemTime};
+
+fn main() {
+    let then = Instant::now();
+
+    assert_eq!(Duration::from_secs(42), then.elapsed());
+
+    assert_eq!(
+        SystemTime::UNIX_EPOCH + Duration::from_secs(1431648000),
+        SystemTime::now()
+    );
+}

--- a/wasi-common/src/clocks.rs
+++ b/wasi-common/src/clocks.rs
@@ -30,32 +30,29 @@ pub struct MonotonicClock {
 impl From<&dyn WasiMonotonicClock> for MonotonicClock {
     fn from(clock: &dyn WasiMonotonicClock) -> MonotonicClock {
         MonotonicClock {
-            start: clock.now(Duration::from_millis(1)),
+            start: clock.now(clock.resolution()),
         }
     }
 }
 
 impl MonotonicClock {
     pub fn now(&self, clock: &dyn WasiMonotonicClock) -> Duration {
-        clock.now(self.resolution()).duration_since(self.start)
-    }
-    pub fn resolution(&self) -> Duration {
-        // FIXME bogus value
-        Duration::from_millis(1)
+        clock.now(clock.resolution()).duration_since(self.start)
     }
     pub fn new_timer(&self, initial: Duration) -> MonotonicTimer {
-        MonotonicTimer { initial }
+        MonotonicTimer {
+            start: self.start + initial,
+        }
     }
 }
 
 pub struct MonotonicTimer {
-    initial: Duration,
+    start: Instant,
 }
 
 impl MonotonicTimer {
-    pub fn current(&self) -> Duration {
-        // FIXME totally bogus implementation
-        self.initial
+    pub fn current(&self, clock: &dyn WasiMonotonicClock) -> Duration {
+        clock.now(clock.resolution()).duration_since(self.start)
     }
 }
 
@@ -64,9 +61,6 @@ pub struct WallClock;
 
 impl WallClock {
     pub fn now(&self, clock: &dyn WasiSystemClock) -> SystemTime {
-        clock.now(self.resolution())
-    }
-    pub fn resolution(&self) -> Duration {
-        todo!()
+        clock.now(clock.resolution())
     }
 }

--- a/wasi-common/src/pipe.rs
+++ b/wasi-common/src/pipe.rs
@@ -112,6 +112,14 @@ impl<R: Read + Any + Send + Sync> WasiFile for ReadPipe<R> {
         let n = self.borrow().read_vectored(bufs)?;
         Ok(n.try_into()?)
     }
+    async fn read_vectored_at<'a>(
+        &mut self,
+        bufs: &mut [io::IoSliceMut<'a>],
+        _offset: u64,
+    ) -> Result<u64, Error> {
+        let n = self.borrow().read_vectored(bufs)?;
+        Ok(n.try_into()?)
+    }
 }
 
 /// A virtual pipe write end.


### PR DESCRIPTION
This required fleshing out the `wasi-clocks` host implementation a bit and adding a `read_vectored_at` implementation for `ReadPipe`.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>