### PR TITLE
Add `close` functions for clock handles.

### DIFF
--- a/host/src/clocks.rs
+++ b/host/src/clocks.rs
@@ -70,4 +70,15 @@ impl wasi_clocks::WasiClocks for WasiCtx {
             nanoseconds: res.subsec_nanos(),
         })
     }
+
+    async fn close_monotonic_clock(
+        &mut self,
+        clock: wasi_clocks::MonotonicClock,
+    ) -> anyhow::Result<()> {
+        Ok(self.table_mut().delete_monotonic_clock(clock)?)
+    }
+
+    async fn close_wall_clock(&mut self, clock: wasi_clocks::WallClock) -> anyhow::Result<()> {
+        Ok(self.table_mut().delete_wall_clock(clock)?)
+    }
 }

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -330,3 +330,16 @@ async fn run_directory_list(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()>
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
+
+async fn run_default_clocks(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
+    wasi.command(
+        &mut store,
+        0 as host::Descriptor,
+        1 as host::Descriptor,
+        &[],
+        &[],
+        &[],
+    )
+    .await?;
+    Ok(())
+}

--- a/test-programs/src/bin/default_clocks.rs
+++ b/test-programs/src/bin/default_clocks.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let a = std::time::Instant::now();
+    let b = std::time::Instant::now();
+    let _ = b.checked_duration_since(a).unwrap();
+
+    let c = std::time::SystemTime::now();
+    let d = std::time::SystemTime::now();
+    let _ = c.duration_since(std::time::UNIX_EPOCH).unwrap();
+    let _ = d.duration_since(std::time::UNIX_EPOCH).unwrap();
+}

--- a/wasi-common/src/clocks.rs
+++ b/wasi-common/src/clocks.rs
@@ -24,6 +24,7 @@ pub trait TableWallClockExt {
         &mut self,
         fd: u32,
     ) -> Result<&mut Box<dyn WasiWallClock + Send + Sync>, Error>;
+    fn delete_wall_clock(&mut self, fd: u32) -> Result<(), Error>;
 }
 impl TableWallClockExt for crate::table::Table {
     fn get_wall_clock(&self, fd: u32) -> Result<&(dyn WasiWallClock + Send + Sync), Error> {
@@ -36,6 +37,10 @@ impl TableWallClockExt for crate::table::Table {
     ) -> Result<&mut Box<dyn WasiWallClock + Send + Sync>, Error> {
         self.get_mut::<Box<dyn WasiWallClock + Send + Sync>>(fd)
     }
+    fn delete_wall_clock(&mut self, fd: u32) -> Result<(), Error> {
+        self.delete::<Box<dyn WasiWallClock + Send + Sync>>(fd)
+            .map(|_old| ())
+    }
 }
 
 pub trait TableMonotonicClockExt {
@@ -47,6 +52,7 @@ pub trait TableMonotonicClockExt {
         &mut self,
         fd: u32,
     ) -> Result<&mut Box<dyn WasiMonotonicClock + Send + Sync>, Error>;
+    fn delete_monotonic_clock(&mut self, fd: u32) -> Result<(), Error>;
 }
 impl TableMonotonicClockExt for crate::table::Table {
     fn get_monotonic_clock(
@@ -61,5 +67,9 @@ impl TableMonotonicClockExt for crate::table::Table {
         fd: u32,
     ) -> Result<&mut Box<dyn WasiMonotonicClock + Send + Sync>, Error> {
         self.get_mut::<Box<dyn WasiMonotonicClock + Send + Sync>>(fd)
+    }
+    fn delete_monotonic_clock(&mut self, fd: u32) -> Result<(), Error> {
+        self.delete::<Box<dyn WasiMonotonicClock + Send + Sync>>(fd)
+            .map(|_old| ())
     }
 }

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -84,6 +84,12 @@ interface wasi-clocks {
   ///
   /// The nanoseconds field of the output is always less than 1000000000.
   wall-clock-resolution: func(clock: wall-clock) -> datetime
+
+  /// Closes a monotonic clock handle.
+  close-monotonic-clock: func(clock: monotonic-clock)
+
+  /// Closes a wall clock handle.
+  close-wall-clock: func(clock: wall-clock)
 }
 
 /// # WASI Default Clocks API


### PR DESCRIPTION
Many users won't need these, because they'll just grab one default clock handle and reuse it for the rest of the program. But it should still be possible to close a clock handle.

Also, add a simple test for the clock APIs.