### PR TITLE
fix compile failed by wasmtime::component::Error dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "cranelift-bforest"
 version = "0.92.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "cranelift-entity",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen"
 version = "0.92.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "arrayvec",
  "bumpalo",
@@ -247,7 +247,7 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-meta"
 version = "0.92.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "cranelift-codegen-shared",
 ]
@@ -255,12 +255,12 @@ dependencies = [
 [[package]]
 name = "cranelift-codegen-shared"
 version = "0.92.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 
 [[package]]
 name = "cranelift-entity"
 version = "0.92.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "serde",
 ]
@@ -268,7 +268,7 @@ dependencies = [
 [[package]]
 name = "cranelift-frontend"
 version = "0.92.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -279,12 +279,12 @@ dependencies = [
 [[package]]
 name = "cranelift-isle"
 version = "0.92.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 
 [[package]]
 name = "cranelift-native"
 version = "0.92.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "cranelift-wasm"
 version = "0.92.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "wasmtime"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-asm-macros"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "cfg-if",
 ]
@@ -1555,7 +1555,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-cache"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "anyhow",
  "base64",
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-macro"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1587,12 +1587,12 @@ dependencies = [
 [[package]]
 name = "wasmtime-component-util"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 
 [[package]]
 name = "wasmtime-cranelift"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1612,7 +1612,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-environ"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -1633,7 +1633,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-fiber"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1645,7 +1645,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1669,7 +1669,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-debug"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "object",
  "once_cell",
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-jit-icache-coherence"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-runtime"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "anyhow",
  "cc",
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "wasmtime-types"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -1725,8 +1725,9 @@ dependencies = [
 [[package]]
 name = "wasmtime-wit-bindgen"
 version = "5.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#a76e0e8aa57220fe9c75f810c293ba2694d65e7a"
+source = "git+https://github.com/bytecodealliance/wasmtime#52ba72f3412357e2dde616df9c6b954d34431ebe"
 dependencies = [
+ "anyhow",
  "heck",
  "wit-parser",
 ]

--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -17,12 +17,12 @@ fn contains<T: BitAnd<Output = T> + Eq + Copy>(flags: T, flag: T) -> bool {
     (flags & flag) == flag
 }
 
-fn convert(error: wasi_common::Error) -> wasmtime::component::Error<wasi_filesystem::Errno> {
+fn convert(error: wasi_common::Error) -> anyhow::Error {
     if let Some(errno) = error.downcast_ref() {
         use wasi_common::Errno::*;
         use wasi_filesystem::Errno;
 
-        wasmtime::component::Error::new(match errno {
+        match errno {
             Acces => Errno::Access,
             Addrinuse => Errno::Addrinuse,
             Addrnotavail => Errno::Addrnotavail,
@@ -93,11 +93,12 @@ fn convert(error: wasi_common::Error) -> wasmtime::component::Error<wasi_filesys
             Xdev => Errno::Xdev,
             Success | Dom | Notcapable | Notsock | Proto | Protonosupport | Prototype | TooBig
             | Notconn => {
-                return error.into().into();
+                return error.into();
             }
-        })
+        }
+        .into()
     } else {
-        error.into().into()
+        error.into()
     }
 }
 
@@ -225,21 +226,21 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
     ) -> HostResult<wasi_filesystem::DescriptorFlags, wasi_filesystem::Errno> {
         let table = self.table();
         if table.is::<Box<dyn WasiFile>>(fd) {
-            Ok(table
+            Ok(Ok(table
                 .get_file(fd)
                 .map_err(convert)?
                 .get_fdflags()
                 .await
                 .map_err(convert)?
-                .into())
+                .into()))
         } else if table.is::<Box<dyn WasiDir>>(fd) {
-            Ok(table
+            Ok(Ok(table
                 .get_dir(fd)
                 .map_err(convert)?
                 .get_fdflags()
                 .await
                 .map_err(convert)?
-                .into())
+                .into()))
         } else {
             Err(wasi_filesystem::Errno::Badf.into())
         }
@@ -251,15 +252,15 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
     ) -> HostResult<wasi_filesystem::DescriptorType, wasi_filesystem::Errno> {
         let table = self.table();
         if table.is::<Box<dyn WasiFile>>(fd) {
-            Ok(table
+            Ok(Ok(table
                 .get_file(fd)
                 .map_err(convert)?
                 .get_filetype()
                 .await
                 .map_err(convert)?
-                .into())
+                .into()))
         } else if table.is::<Box<dyn WasiDir>>(fd) {
-            Ok(wasi_filesystem::DescriptorType::Directory)
+            Ok(Ok(wasi_filesystem::DescriptorType::Directory))
         } else {
             Err(wasi_filesystem::Errno::Badf.into())
         }
@@ -307,7 +308,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
 
         buffer.truncate(bytes_read.try_into().unwrap());
 
-        Ok((buffer, end))
+        Ok(Ok((buffer, end)))
     }
 
     async fn pwrite(
@@ -323,7 +324,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
             .await
             .map_err(convert)?;
 
-        Ok(wasi_filesystem::Size::try_from(bytes_written).unwrap())
+        Ok(Ok(wasi_filesystem::Size::try_from(bytes_written).unwrap()))
     }
 
     async fn readdir(
@@ -368,21 +369,21 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
     ) -> HostResult<wasi_filesystem::DescriptorStat, wasi_filesystem::Errno> {
         let table = self.table();
         if table.is::<Box<dyn WasiFile>>(fd) {
-            Ok(table
+            Ok(Ok(table
                 .get_file(fd)
                 .map_err(convert)?
                 .get_filestat()
                 .await
                 .map_err(convert)?
-                .into())
+                .into()))
         } else if table.is::<Box<dyn WasiDir>>(fd) {
-            Ok(table
+            Ok(Ok(table
                 .get_dir(fd)
                 .map_err(convert)?
                 .get_filestat()
                 .await
                 .map_err(convert)?
-                .into())
+                .into()))
         } else {
             Err(wasi_filesystem::Errno::Badf.into())
         }
@@ -449,7 +450,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
                 .await
                 .map_err(convert)?;
             drop(dir);
-            Ok(table.push(Box::new(child_dir)).map_err(convert)?)
+            Ok(Ok(table.push(Box::new(child_dir)).map_err(convert)?))
         } else {
             let file = dir
                 .open_file(
@@ -463,7 +464,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
                 .await
                 .map_err(convert)?;
             drop(dir);
-            Ok(table.push(Box::new(file)).map_err(convert)?)
+            Ok(Ok(table.push(Box::new(file)).map_err(convert)?))
         }
     }
 
@@ -598,7 +599,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         // Insert the stream view into the table.
         let index = self.table_mut().push(Box::new(boxed)).map_err(convert)?;
 
-        Ok(index)
+        Ok(Ok(index))
     }
 
     async fn write_via_stream(
@@ -620,7 +621,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         // Insert the stream view into the table.
         let index = self.table_mut().push(Box::new(boxed)).map_err(convert)?;
 
-        Ok(index)
+        Ok(Ok(index))
     }
 
     async fn append_via_stream(
@@ -641,6 +642,6 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         // Insert the stream view into the table.
         let index = self.table_mut().push(Box::new(boxed)).map_err(convert)?;
 
-        Ok(index)
+        Ok(Ok(index))
     }
 }

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -8,7 +8,7 @@ mod stderr;
 mod tcp;
 pub use wasi_common::{table::Table, WasiCtx};
 
-type HostResult<T, E> = Result<T, wasmtime::component::Error<E>>;
+type HostResult<T, E> = anyhow::Result<Result<T, E>>;
 
 wasmtime::component::bindgen!({
     path: "../wit/wasi.wit",

--- a/host/src/poll.rs
+++ b/host/src/poll.rs
@@ -6,11 +6,11 @@ use crate::{
 use wasi_common::clocks::TableMonotonicClockExt;
 use wasi_common::stream::TableStreamExt;
 
-fn convert(error: wasi_common::Error) -> wasmtime::component::Error<StreamError> {
+fn convert(error: wasi_common::Error) -> anyhow::Error {
     if let Some(_errno) = error.downcast_ref() {
-        wasmtime::component::Error::new(wasi_poll::StreamError {})
+        anyhow::Error::new(wasi_poll::StreamError {})
     } else {
-        error.into().into()
+        error.into()
     }
 }
 
@@ -92,7 +92,7 @@ impl WasiPoll for WasiCtx {
 
         buffer.truncate(bytes_read as usize);
 
-        Ok((buffer, end))
+        Ok(Ok((buffer, end)))
     }
 
     async fn write_stream(
@@ -105,7 +105,7 @@ impl WasiPoll for WasiCtx {
 
         let bytes_written: u64 = s.write(&bytes).await.map_err(convert)?;
 
-        Ok(Size::try_from(bytes_written).unwrap())
+        Ok(Ok(Size::try_from(bytes_written).unwrap()))
     }
 
     async fn skip_stream(
@@ -118,7 +118,7 @@ impl WasiPoll for WasiCtx {
 
         let (bytes_skipped, end) = s.skip(len).await.map_err(convert)?;
 
-        Ok((bytes_skipped, end))
+        Ok(Ok((bytes_skipped, end)))
     }
 
     async fn write_repeated_stream(
@@ -132,7 +132,7 @@ impl WasiPoll for WasiCtx {
 
         let bytes_written: u64 = s.write_repeated(byte, len).await.map_err(convert)?;
 
-        Ok(bytes_written)
+        Ok(Ok(bytes_written))
     }
 
     async fn splice_stream(


### PR DESCRIPTION
This is fix for `wasmtime::component::Error` dropped from https://github.com/bytecodealliance/wasmtime/pull/5397 to keep `host` compiling.

I found https://github.com/bytecodealliance/preview2-prototyping/issues/32 and https://github.com/bytecodealliance/preview2-prototyping/pull/26 talking about this case. PR is outdated and It seems a new design for `HostResult` is comming. 

But now I'm trying to run wasm `component-model` with wasi host bindings. So I think `host` should be compiled correctly.