### PR TITLE
fix a couple of host/src/main.rs issues

### DIFF
--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -19,17 +19,24 @@ async fn main() -> Result<()> {
     let mut config = Config::new();
     config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Enable);
     config.wasm_component_model(true);
+    config.async_support(true);
 
     let engine = Engine::new(&config)?;
     let component = Component::from_file(&engine, &input)?;
     let mut linker = Linker::new(&engine);
     add_to_linker(&mut linker, |x| x)?;
 
-    let mut store = Store::new(&engine, WasiCtxBuilder::new().build());
+    let mut store = Store::new(
+        &engine,
+        WasiCtxBuilder::new()
+            .inherit_stdin()
+            .inherit_stdout()
+            .build(),
+    );
 
     let (wasi, _instance) = Wasi::instantiate_async(&mut store, &component, &linker).await?;
 
-    let result: Result<(), ()> = wasi.command(&mut store, 0, 0, &[], &[], &[]).await?;
+    let result: Result<(), ()> = wasi.command(&mut store, 0, 1, &[], &[], &[]).await?;
 
     if result.is_err() {
         anyhow::bail!("command returned with failing exit status");


### PR DESCRIPTION
1. It needed a `config.async_support(true)` to actually work at all.
2. Add `inherit_stdin` and `inherit_stdout` calls when building WasiCtx to make stdio useful.
3. Set stdout descriptor to 1.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>