### PR TITLE
Teach poll_oneoff how to poll for immediately-available I/O

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,11 @@ jobs:
             os: macos-latest
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update stable
-    - run: rustup default stable
-    - run: rustup target add wasm32-wasi wasm32-unknown-unknown
+      # TODO: Remove +nightly once lambda-fairy/rust-errno#66 is released and
+      # rust-lang/rust#105395 reaches stable.
+    - run: rustup update nightly
+    - run: rustup default nightly
+    - run: rustup target add --toolchain=nightly wasm32-wasi wasm32-unknown-unknown
     - run: cargo build --target wasm32-unknown-unknown
     - run: cargo run -p verify -- ./target/wasm32-unknown-unknown/debug/wasi_snapshot_preview1.wasm
     - run: cargo build --target wasm32-unknown-unknown --features command

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1182,7 +1182,7 @@ name = "test-programs"
 version = "0.0.0"
 dependencies = [
  "getrandom",
- "wasi",
+ "rustix",
  "wit-bindgen-guest-rust",
 ]
 

--- a/host/src/poll.rs
+++ b/host/src/poll.rs
@@ -57,7 +57,7 @@ impl WasiPoll for WasiCtx {
                         when,
                         absolute,
                         Userdata::from(index as u64),
-                    )?;
+                    );
                 }
             }
         }

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -199,6 +199,25 @@ async fn run_stdin(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
+async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
+    store
+        .data_mut()
+        .set_stdin(Box::new(ReadPipe::new(Cursor::new(
+            "So rested he by the Tumtum tree",
+        ))));
+
+    wasi.command(
+        &mut store,
+        0 as host::WasiStream,
+        1 as host::WasiStream,
+        &[],
+        &[],
+        &[],
+    )
+    .await?
+    .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
+}
+
 async fn run_env(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
     wasi.command(
         &mut store,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1474,8 +1474,10 @@ pub unsafe extern "C" fn poll_oneoff(
             )
     );
 
+    // Store the future handles at the beginning, and the bool results at the
+    // end, so that we don't clobber the bool results when writting the events.
     let futures = out as *mut c_void as *mut WasiFuture;
-    let results = futures.add(nsubscriptions) as *mut c_void as *mut u8;
+    let results = out.add(nsubscriptions).cast::<u8>().sub(nsubscriptions);
 
     // Indefinite sleeping is not supported in preview1.
     if nsubscriptions == 0 {

--- a/test-programs/Cargo.toml
+++ b/test-programs/Cargo.toml
@@ -6,5 +6,5 @@ publish = false
 
 [dependencies]
 getrandom = "0.2.8"
-wasi = "0.11"
+rustix = "0.36.6"
 wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }

--- a/test-programs/macros/build.rs
+++ b/test-programs/macros/build.rs
@@ -26,7 +26,10 @@ fn main() {
     let wasi_adapter = fs::read(&wasi_adapter).unwrap();
 
     let mut cmd = Command::new("cargo");
-    cmd.arg("build")
+    // TODO: Remove +nightly once lambda-fairy/rust-errno#66 is released and
+    // rust-lang/rust#105395 reaches stable.
+    cmd.arg("+nightly")
+        .arg("build")
         .current_dir("..")
         .arg("--target=wasm32-wasi")
         .env("CARGO_TARGET_DIR", &out_dir)

--- a/test-programs/macros/build.rs
+++ b/test-programs/macros/build.rs
@@ -26,10 +26,7 @@ fn main() {
     let wasi_adapter = fs::read(&wasi_adapter).unwrap();
 
     let mut cmd = Command::new("cargo");
-    // TODO: Remove +nightly once lambda-fairy/rust-errno#66 is released and
-    // rust-lang/rust#105395 reaches stable.
-    cmd.arg("+nightly")
-        .arg("build")
+    cmd.arg("build")
         .current_dir("..")
         .arg("--target=wasm32-wasi")
         .env("CARGO_TARGET_DIR", &out_dir)

--- a/test-programs/src/bin/poll_stdin.rs
+++ b/test-programs/src/bin/poll_stdin.rs
@@ -1,0 +1,9 @@
+use rustix::io::{PollFd, PollFlags};
+
+fn main() {
+    let stdin = std::io::stdin();
+    let mut pollfds = vec![PollFd::new(&stdin, PollFlags::IN)];
+    let num = rustix::io::poll(&mut pollfds, -1).unwrap();
+    assert_eq!(num, 1);
+    assert_eq!(pollfds[0].revents(), PollFlags::IN);
+}

--- a/wasi-common/cap-std-sync/src/sched.rs
+++ b/wasi-common/cap-std-sync/src/sched.rs
@@ -148,7 +148,6 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
 
     Ok(())
 }
-
 pub struct SyncSched {}
 impl SyncSched {
     pub fn new() -> Self {

--- a/wasi-common/src/sched.rs
+++ b/wasi-common/src/sched.rs
@@ -46,7 +46,7 @@ impl<'a> Poll<'a> {
         deadline: u64,
         absolute: bool,
         ud: Userdata,
-    ) -> Result<(), Error> {
+    ) {
         let deadline = if absolute {
             // Convert an absolute deadline to a relative one.
             deadline.saturating_sub(clock.now())
@@ -57,7 +57,6 @@ impl<'a> Poll<'a> {
             Subscription::MonotonicClock(MonotonicClockSubscription { clock, deadline }),
             ud,
         ));
-        Ok(())
     }
     pub fn subscribe_read(&mut self, stream: &'a dyn WasiStream, ud: Userdata) {
         self.subs.push((

--- a/wasi-common/src/sched.rs
+++ b/wasi-common/src/sched.rs
@@ -1,6 +1,6 @@
 use crate::clocks::WasiMonotonicClock;
 use crate::stream::WasiStream;
-use crate::{Error, ErrorExt};
+use crate::Error;
 pub mod subscription;
 pub use cap_std::time::Duration;
 
@@ -48,9 +48,8 @@ impl<'a> Poll<'a> {
         ud: Userdata,
     ) -> Result<(), Error> {
         let deadline = if absolute {
-            deadline
-                .checked_sub(clock.now())
-                .ok_or_else(Error::overflow)?
+            // Convert an absolute deadline to a relative one.
+            deadline.saturating_sub(clock.now())
         } else {
             deadline
         };

--- a/wasi-common/src/sched/subscription.rs
+++ b/wasi-common/src/sched/subscription.rs
@@ -11,7 +11,7 @@ bitflags! {
 
 pub struct RwSubscription<'a> {
     pub stream: &'a dyn WasiStream,
-    status: Option<Result<(u64, RwEventFlags), Error>>,
+    status: Option<Result<RwEventFlags, Error>>,
 }
 
 impl<'a> RwSubscription<'a> {
@@ -21,13 +21,13 @@ impl<'a> RwSubscription<'a> {
             status: None,
         }
     }
-    pub fn complete(&mut self, size: u64, flags: RwEventFlags) {
-        self.status = Some(Ok((size, flags)))
+    pub fn complete(&mut self, flags: RwEventFlags) {
+        self.status = Some(Ok(flags))
     }
     pub fn error(&mut self, error: Error) {
         self.status = Some(Err(error))
     }
-    pub fn result(&mut self) -> Option<Result<(u64, RwEventFlags), Error>> {
+    pub fn result(&mut self) -> Option<Result<RwEventFlags, Error>> {
         self.status.take()
     }
     pub fn is_complete(&self) -> bool {
@@ -69,7 +69,7 @@ pub enum RwSubscriptionKind {
 
 #[derive(Debug)]
 pub enum SubscriptionResult {
-    ReadWrite(Result<(u64, RwEventFlags), Error>, RwSubscriptionKind),
+    ReadWrite(Result<RwEventFlags, Error>, RwSubscriptionKind),
     MonotonicClock(Result<(), Error>),
 }
 


### PR DESCRIPTION
When a `ReadPipe` is reading from a memory buffer, there is no host file descriptor to poll with, but there doesn't need to be because the contents are immediately available. Teach the `poll_oneoff` function to use system-interface's `ReadReady` trait, which returns the number of bytes read to be read immediately, to implement polling for such input sources.

This also fixes the polyfill to avoid calling `bytes_readable` on non-socket handles, which is needed to make the test pass.