### PR TITLE
Implement `sync` and `datasync` on files and directories.

### DIFF
--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -218,7 +218,24 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         &mut self,
         fd: wasi_filesystem::Descriptor,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        if table.is::<Box<dyn WasiFile>>(fd) {
+            Ok(Ok(table
+                .get_file(fd)
+                .map_err(convert)?
+                .datasync()
+                .await
+                .map_err(convert)?))
+        } else if table.is::<Box<dyn WasiDir>>(fd) {
+            Ok(Ok(table
+                .get_dir(fd)
+                .map_err(convert)?
+                .datasync()
+                .await
+                .map_err(convert)?))
+        } else {
+            Err(wasi_filesystem::Errno::Badf.into())
+        }
     }
 
     async fn flags(
@@ -382,7 +399,24 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         &mut self,
         fd: wasi_filesystem::Descriptor,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        if table.is::<Box<dyn WasiFile>>(fd) {
+            Ok(Ok(table
+                .get_file(fd)
+                .map_err(convert)?
+                .sync()
+                .await
+                .map_err(convert)?))
+        } else if table.is::<Box<dyn WasiDir>>(fd) {
+            Ok(Ok(table
+                .get_dir(fd)
+                .map_err(convert)?
+                .sync()
+                .await
+                .map_err(convert)?))
+        } else {
+            Err(wasi_filesystem::Errno::Badf.into())
+        }
     }
 
     async fn create_directory_at(

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -271,6 +271,31 @@ async fn run_file_append(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
     Ok(())
 }
 
+async fn run_file_dir_sync(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    std::fs::File::create(dir.path().join("bar.txt"))?
+        .write_all(b"'Twas brillig, and the slithy toves.\n")?;
+
+    let descriptor =
+        store
+            .data_mut()
+            .push_dir(Box::new(wasi_cap_std_sync::dir::Dir::from_cap_std(
+                Dir::from_std_file(std::fs::File::open(dir.path())?),
+            )))?;
+
+    wasi.command(
+        &mut store,
+        0 as host::Descriptor,
+        1 as host::Descriptor,
+        &[],
+        &[],
+        &[(descriptor, "/")],
+    )
+    .await?
+    .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
+}
+
 async fn run_exit_success(mut store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
     let r = wasi
         .command(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -847,14 +847,14 @@ pub unsafe extern "C" fn fd_readdir(
                 let dir = state.get_dir(fd)?;
                 iter = DirEntryIterator {
                     state,
-                    cookie: 0,
+                    cookie: wasi::DIRCOOKIE_START,
                     use_cache: false,
                     stream: DirEntryStream(wasi_filesystem::readdir(dir.fd)?),
                 };
 
                 // Skip to the entry that is requested by the `cookie`
                 // parameter.
-                for _ in 0..cookie {
+                for _ in wasi::DIRCOOKIE_START..cookie {
                     match iter.next() {
                         Some(Ok(_)) => {}
                         Some(Err(e)) => return Err(e),
@@ -2205,7 +2205,7 @@ impl State {
                 dirent_cache: DirentCache {
                     stream: Cell::new(None),
                     for_fd: Cell::new(0),
-                    cookie: Cell::new(0),
+                    cookie: Cell::new(wasi::DIRCOOKIE_START),
                     cached_dirent: Cell::new(wasi::Dirent {
                         d_next: 0,
                         d_ino: 0,

--- a/test-programs/src/bin/file_dir_sync.rs
+++ b/test-programs/src/bin/file_dir_sync.rs
@@ -1,0 +1,11 @@
+fn main() -> std::io::Result<()> {
+    let file = std::fs::File::open("bar.txt")?;
+    file.sync_all()?;
+    file.sync_data()?;
+
+    let dir = std::fs::File::open(".")?;
+    dir.sync_all()?;
+    dir.sync_data()?;
+
+    Ok(())
+}

--- a/wasi-common/cap-std-sync/src/file.rs
+++ b/wasi-common/cap-std-sync/src/file.rs
@@ -40,11 +40,11 @@ impl WasiFile for File {
         Ok(Box::new(Self(clone)))
     }
 
-    async fn datasync(&mut self) -> Result<(), Error> {
+    async fn datasync(&self) -> Result<(), Error> {
         self.0.sync_data()?;
         Ok(())
     }
-    async fn sync(&mut self) -> Result<(), Error> {
+    async fn sync(&self) -> Result<(), Error> {
         self.0.sync_all()?;
         Ok(())
     }

--- a/wasi-common/src/dir.rs
+++ b/wasi-common/src/dir.rs
@@ -27,6 +27,10 @@ pub trait WasiDir: Send + Sync {
         Err(Error::not_supported())
     }
 
+    async fn datasync(&self) -> Result<(), Error>;
+
+    async fn sync(&self) -> Result<(), Error>;
+
     async fn get_fdflags(&self) -> Result<FdFlags, Error> {
         Ok(FdFlags::empty())
     }

--- a/wasi-common/src/file.rs
+++ b/wasi-common/src/file.rs
@@ -26,13 +26,9 @@ pub trait WasiFile: Send + Sync {
         Err(Error::badf())
     }
 
-    async fn datasync(&mut self) -> Result<(), Error> {
-        Ok(())
-    }
+    async fn datasync(&self) -> Result<(), Error>;
 
-    async fn sync(&mut self) -> Result<(), Error> {
-        Ok(())
-    }
+    async fn sync(&self) -> Result<(), Error>;
 
     async fn get_fdflags(&self) -> Result<FdFlags, Error> {
         Ok(FdFlags::empty())

--- a/wasi-common/tokio/src/file.rs
+++ b/wasi-common/tokio/src/file.rs
@@ -107,10 +107,10 @@ macro_rules! wasi_file_impl {
             async fn try_clone(&mut self) -> Result<Box<dyn WasiFile>, Error> {
                 block_on_dummy_executor(|| self.0.try_clone())
             }
-            async fn datasync(&mut self) -> Result<(), Error> {
+            async fn datasync(&self) -> Result<(), Error> {
                 block_on_dummy_executor(|| self.0.datasync())
             }
-            async fn sync(&mut self) -> Result<(), Error> {
+            async fn sync(&self) -> Result<(), Error> {
                 block_on_dummy_executor(|| self.0.sync())
             }
             async fn get_filetype(&mut self) -> Result<FileType, Error> {


### PR DESCRIPTION
On Windows, there doesn't appear to be a way to sync a directory, to ensure that the directory entry for a file is sync'd. So for now, just silently succeed. I've opened WebAssembly/wasi-filesystem#79 to track this at the spec level.