### PR TITLE
Rename the `wasi` world to `wasi-command`.

### DIFF
--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use host::{add_to_linker, Wasi};
+use host::{add_to_linker, WasiCommand};
 use std::path::PathBuf;
 use wasi_cap_std_sync::WasiCtxBuilder;
 use wasmtime::{
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
             .build(),
     );
 
-    let (wasi, _instance) = Wasi::instantiate_async(&mut store, &component, &linker).await?;
+    let (wasi, _instance) = WasiCommand::instantiate_async(&mut store, &component, &linker).await?;
 
     let result: Result<(), ()> = wasi.command(&mut store, 0, 1, &[], &[], &[]).await?;
 

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -1160,7 +1160,7 @@ interface wasi-tcp {
   bytes-writable: func(s: socket) -> result<bytes-result, error>
 }
 
-world wasi {
+world wasi-command {
   import wasi-clocks: wasi-clocks
   import wasi-default-clocks: wasi-default-clocks
   import wasi-logging: wasi-logging


### PR DESCRIPTION
There will be other worlds in WASI, so rename the `wasi-command` world to accomodate them.