### PR TITLE
Add `eprintln`, `unreachable`, and other macros.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
+name = "byte-array"
+version = "0.0.0"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1442,7 @@ dependencies = [
 name = "wasi_snapshot_preview1"
 version = "0.0.0"
 dependencies = [
+ "byte-array",
  "object",
  "wasi",
  "wasm-encoder 0.18.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [workspace]
-members = ["verify", "host", "test-programs", "test-programs/wasi-tests", "wasi-common"]
+members = ["verify", "host", "test-programs", "test-programs/wasi-tests", "wasi-common", "byte-array"]
 
 [workspace.package]
 version = "0.0.0"
@@ -30,6 +30,7 @@ system-interface = { version = "0.25.1", features = ["cap_std_impls"] }
 [dependencies]
 wasi = { version = "0.11.0", default-features = false }
 wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", default-features = false, features = ["macros"] }
+byte-array = { path = "byte-array" }
 
 [build-dependencies]
 wasm-encoder = "0.18.0"

--- a/byte-array/Cargo.toml
+++ b/byte-array/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "byte-array"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true

--- a/byte-array/src/lib.rs
+++ b/byte-array/src/lib.rs
@@ -1,0 +1,98 @@
+extern crate proc_macro;
+
+use proc_macro::{Delimiter, Group, Literal, Punct, Spacing, TokenStream, TokenTree};
+
+/// Expand a `str` literal into a byte array.
+#[proc_macro]
+pub fn str(input: TokenStream) -> TokenStream {
+    let rv = convert_str(input);
+
+    vec![TokenTree::Group(Group::new(
+        Delimiter::Bracket,
+        rv.into_iter().collect(),
+    ))]
+    .into_iter()
+    .collect()
+}
+
+/// The same as `str` but appends a `'\n'`.
+#[proc_macro]
+pub fn str_nl(input: TokenStream) -> TokenStream {
+    let mut rv = convert_str(input);
+
+    rv.push(TokenTree::Literal(Literal::u8_suffixed(b'\n')));
+
+    vec![TokenTree::Group(Group::new(
+        Delimiter::Bracket,
+        rv.into_iter().collect(),
+    ))]
+    .into_iter()
+    .collect()
+}
+
+fn convert_str(input: TokenStream) -> Vec<TokenTree> {
+    let mut it = input.into_iter();
+
+    let mut tokens = Vec::new();
+    match it.next() {
+        Some(TokenTree::Literal(l)) => {
+            for b in to_string(l).into_bytes() {
+                tokens.push(TokenTree::Literal(Literal::u8_suffixed(b)));
+                tokens.push(TokenTree::Punct(Punct::new(',', Spacing::Alone)));
+            }
+        }
+        _ => panic!(),
+    }
+
+    assert!(it.next().is_none());
+    tokens
+}
+
+fn to_string(lit: Literal) -> String {
+    let formatted = lit.to_string();
+
+    let mut it = formatted.chars();
+    assert_eq!(it.next(), Some('"'));
+
+    let mut rv = String::new();
+    loop {
+        match it.next() {
+            Some('"') => match it.next() {
+                Some(_) => panic!(),
+                None => break,
+            },
+            Some('\\') => match it.next() {
+                Some('x') => {
+                    let hi = it.next().unwrap().to_digit(16).unwrap();
+                    let lo = it.next().unwrap().to_digit(16).unwrap();
+                    let v = (hi << 16) | lo;
+                    rv.push(v as u8 as char);
+                }
+                Some('u') => {
+                    assert_eq!(it.next(), Some('{'));
+                    let mut c = it.next().unwrap();
+                    let mut ch = 0;
+                    while let Some(v) = c.to_digit(16) {
+                        ch *= 16;
+                        ch |= v;
+                        c = it.next().unwrap();
+                    }
+                    assert_eq!(c, '}');
+                    rv.push(::std::char::from_u32(ch).unwrap());
+                }
+                Some('0') => rv.push('\0'),
+                Some('\\') => rv.push('\\'),
+                Some('\"') => rv.push('\"'),
+                Some('r') => rv.push('\r'),
+                Some('n') => rv.push('\n'),
+                Some('t') => rv.push('\t'),
+                Some(_) => panic!(),
+                None => panic!(),
+            },
+            Some(c) => rv.push(c),
+            None => panic!(),
+        }
+    }
+
+    rv
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,76 @@
+//! Minimal versions of standard-library panicking and printing macros.
+//!
+//! We're avoiding static initializers, so we can't have things like string
+//! literals. Replace the standard assert macros with simpler implementations.
+
+/// A minimal `eprint` for debugging.
+#[allow(unused_macros)]
+macro_rules! eprint {
+    ($arg:tt) => {{
+        // We have to expand string literals into byte arrays to prevent them
+        // from getting statically initialized.
+        let message = byte_array::str!($arg);
+        crate::bindings::wasi_stderr::print(&message);
+    }};
+}
+
+/// A minimal `eprintln` for debugging.
+#[allow(unused_macros)]
+macro_rules! eprintln {
+    ($arg:tt) => {{
+        // We have to expand string literals into byte arrays to prevent them
+        // from getting statically initialized.
+        let message = byte_array::str_nl!($arg);
+        crate::bindings::wasi_stderr::print(&message);
+    }};
+}
+
+pub(crate) fn eprint_u32(x: u32) {
+    if x == 0 {
+        eprint!("0");
+    } else {
+        eprint_u32_impl(x)
+    }
+
+    fn eprint_u32_impl(x: u32) {
+        if x != 0 {
+            eprint_u32_impl(x / 10);
+
+            let digit = [b'0' + ((x % 10) as u8)];
+            crate::bindings::wasi_stderr::print(&digit);
+        }
+    }
+}
+
+/// A minimal `unreachable`.
+macro_rules! unreachable {
+    () => {{
+        eprint!("unreachable executed at line ");
+        crate::macros::eprint_u32(line!());
+        wasm32::unreachable()
+    }};
+
+    ($arg:tt) => {{
+        eprint!("unreachable executed at line ");
+        crate::macros::eprint_u32(line!());
+        eprint!(": ");
+        eprintln!($arg);
+        wasm32::unreachable()
+    }};
+}
+
+/// A minimal `assert`.
+macro_rules! assert {
+    ($cond:expr $(,)?) => {
+        if !$cond {
+            unreachable!("assertion failed")
+        }
+    };
+}
+
+/// A minimal `assert_eq`.
+macro_rules! assert_eq {
+    ($left:expr, $right:expr $(,)?) => {
+        assert!($left == $right);
+    };
+}


### PR DESCRIPTION
Add a `byte-array` proc-macro crate for converting strings into byte arrays that don't use static initializers, and use it to implement `eprintln`, an `unreachable` that prints the line number, and other macros.