### PR TITLE
implement some filesystem primitives

### DIFF
--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -14,6 +14,7 @@ use wasi_common::{
     WasiDir, WasiFile,
 };
 
+// FIXME: guest rust bindgen should add this method to all flags.
 fn contains<T: BitAnd<Output = T> + Eq + Copy>(flags: T, flag: T) -> bool {
     (flags & flag) == flag
 }
@@ -424,7 +425,13 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         fd: wasi_filesystem::Descriptor,
         path: String,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        Ok(Ok(table
+            .get_dir(fd)
+            .map_err(convert)?
+            .create_dir(&path)
+            .await
+            .map_err(convert)?))
     }
 
     async fn stat(
@@ -459,7 +466,17 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         at_flags: wasi_filesystem::AtFlags,
         path: String,
     ) -> HostResult<wasi_filesystem::DescriptorStat, wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        Ok(Ok(table
+            .get_dir(fd)
+            .map_err(convert)?
+            .get_path_filestat(
+                &path,
+                contains(at_flags, wasi_filesystem::AtFlags::SYMLINK_FOLLOW),
+            )
+            .await
+            .map(wasi_filesystem::DescriptorStat::from)
+            .map_err(convert)?))
     }
 
     async fn set_times_at(
@@ -554,7 +571,13 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         fd: wasi_filesystem::Descriptor,
         path: String,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        Ok(Ok(table
+            .get_dir(fd)
+            .map_err(convert)?
+            .remove_dir(&path)
+            .await
+            .map_err(convert)?))
     }
 
     async fn rename_at(
@@ -573,7 +596,13 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         old_path: String,
         new_path: String,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        Ok(Ok(table
+            .get_dir(fd)
+            .map_err(convert)?
+            .symlink(&old_path, &new_path)
+            .await
+            .map_err(convert)?))
     }
 
     async fn unlink_file_at(
@@ -581,7 +610,13 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         fd: wasi_filesystem::Descriptor,
         path: String,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        Ok(Ok(table
+            .get_dir(fd)
+            .map_err(convert)?
+            .unlink_file(&path)
+            .await
+            .map_err(convert)?))
     }
 
     async fn change_file_permissions_at(

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -18,6 +18,14 @@ use wasmtime::{
 
 test_programs_macros::tests!();
 
+// FIXME: a bunch of these test cases are expected to fail, either by
+// returning an Err or by panicking. Rather than try to juggle the
+// intersection of catch_unwind and async, we use this boolean to
+// short-circuit a bunch of tests expected to blow up. Developers may change
+// this redefintion to `false` locally  to see if any of the failing tests
+// start passing as you add functionality.
+const EXPECT_FAIL: bool = true;
+
 async fn instantiate(path: &str) -> Result<(Store<WasiCtx>, Wasi)> {
     println!("{}", path);
 
@@ -459,7 +467,7 @@ async fn run_clock_time_get(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_close_preopen(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -467,15 +475,11 @@ async fn run_close_preopen(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_dangling_fd(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 
 async fn run_dangling_symlink(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -483,7 +487,7 @@ async fn run_dangling_symlink(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_directory_seek(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -491,7 +495,7 @@ async fn run_directory_seek(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_fd_advise(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -499,7 +503,7 @@ async fn run_fd_advise(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_fd_filestat_get(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -507,7 +511,7 @@ async fn run_fd_filestat_get(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_fd_filestat_set(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -515,7 +519,7 @@ async fn run_fd_filestat_set(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_fd_flags_set(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -523,15 +527,11 @@ async fn run_fd_flags_set(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_fd_readdir(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 
 async fn run_file_allocate(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -539,15 +539,11 @@ async fn run_file_allocate(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_file_pread_pwrite(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 
 async fn run_file_seek_tell(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -559,15 +555,11 @@ async fn run_file_truncation(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_file_unbuffered_write(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 
 async fn run_interesting_paths(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -575,15 +567,11 @@ async fn run_interesting_paths(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> 
 }
 
 async fn run_isatty(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 
 async fn run_nofollow_errors(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -591,15 +579,11 @@ async fn run_nofollow_errors(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_path_exists(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 
 async fn run_path_filestat(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -607,7 +591,7 @@ async fn run_path_filestat(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_path_link(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -615,7 +599,7 @@ async fn run_path_link(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_path_open_create_existing(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -623,7 +607,7 @@ async fn run_path_open_create_existing(store: Store<WasiCtx>, wasi: Wasi) -> Res
 }
 
 async fn run_path_open_dirfd_not_dir(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -631,7 +615,7 @@ async fn run_path_open_dirfd_not_dir(store: Store<WasiCtx>, wasi: Wasi) -> Resul
 }
 
 async fn run_path_open_missing(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -639,7 +623,7 @@ async fn run_path_open_missing(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> 
 }
 
 async fn run_path_open_read_without_rights(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -647,7 +631,7 @@ async fn run_path_open_read_without_rights(store: Store<WasiCtx>, wasi: Wasi) ->
 }
 
 async fn run_path_rename(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -655,7 +639,7 @@ async fn run_path_rename(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_path_rename_dir_trailing_slashes(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -663,7 +647,7 @@ async fn run_path_rename_dir_trailing_slashes(store: Store<WasiCtx>, wasi: Wasi)
 }
 
 async fn run_path_rename_file_trailing_slashes(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -671,7 +655,7 @@ async fn run_path_rename_file_trailing_slashes(store: Store<WasiCtx>, wasi: Wasi
 }
 
 async fn run_path_symlink_trailing_slashes(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -679,7 +663,7 @@ async fn run_path_symlink_trailing_slashes(store: Store<WasiCtx>, wasi: Wasi) ->
 }
 
 async fn run_poll_oneoff_files(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -687,7 +671,7 @@ async fn run_poll_oneoff_files(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> 
 }
 
 async fn run_poll_oneoff_stdio(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -695,7 +679,7 @@ async fn run_poll_oneoff_stdio(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> 
 }
 
 async fn run_readlink(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -703,7 +687,7 @@ async fn run_readlink(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_remove_directory_trailing_slashes(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -711,7 +695,7 @@ async fn run_remove_directory_trailing_slashes(store: Store<WasiCtx>, wasi: Wasi
 }
 
 async fn run_remove_nonempty_directory(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -719,7 +703,7 @@ async fn run_remove_nonempty_directory(store: Store<WasiCtx>, wasi: Wasi) -> Res
 }
 
 async fn run_renumber(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -735,15 +719,11 @@ async fn run_stdio(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_symlink_create(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 
 async fn run_symlink_filestat(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -751,7 +731,7 @@ async fn run_symlink_filestat(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_symlink_loop(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -759,7 +739,7 @@ async fn run_symlink_loop(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_truncation_rights(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }
@@ -767,7 +747,7 @@ async fn run_truncation_rights(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> 
 }
 
 async fn run_unlink_file_trailing_slashes(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
-    if true {
+    if EXPECT_FAIL {
         // TODO!
         return Ok(());
     }

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -475,6 +475,10 @@ async fn run_close_preopen(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
 }
 
 async fn run_dangling_fd(store: Store<WasiCtx>, wasi: Wasi) -> Result<()> {
+    if EXPECT_FAIL && cfg!(windows) {
+        // TODO!
+        return Ok(());
+    }
     run_with_temp_dir(store, wasi).await
 }
 

--- a/test-programs/macros/src/lib.rs
+++ b/test-programs/macros/src/lib.rs
@@ -9,8 +9,7 @@ pub fn tests(_input: TokenStream) -> TokenStream {
         let name = quote::format_ident!("{}", stem);
         let runner = quote::format_ident!("run_{}", stem);
         quote! {
-            #[tokio::test]
-            #[test_log::test]
+            #[test_log::test(tokio::test)]
             async fn #name() -> anyhow::Result<()> {
                 let (store, inst) = instantiate(#file).await?;
                 #runner(store, inst).await


### PR DESCRIPTION
## Host

Filled in trivial (in terms of WasiDir) implementations of the following host filesystem operations:

* `create_directory_at`
* `stat`
* `remove_directory_at`
* `symlink_at`
* `unlink_file_at`

## Tests

Switch `if true { /* TODO */ return Ok(()) }` short-circuiting logic to use `if EXPECT_FAIL` with a global constant, which makes it easier to run all tests to see which previously failing ones pass.

The following tests now appear to pass:
* `dangling_fd`
* `file_pread_pwrite`
* `file_unbuffered_write`
* `isatty`
* `path_exists`
* `symlink_create`
