### PR TITLE
On Windows, ignore access-denied errors from `sync_all`.

### DIFF
--- a/test-programs/Cargo.toml
+++ b/test-programs/Cargo.toml
@@ -7,4 +7,5 @@ publish = false
 [dependencies]
 getrandom = "0.2.8"
 rustix = "0.36.6"
+cap-std = "1.0.3"
 wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindgen" }

--- a/test-programs/src/bin/file_dir_sync.rs
+++ b/test-programs/src/bin/file_dir_sync.rs
@@ -3,9 +3,12 @@ fn main() -> std::io::Result<()> {
     file.sync_all()?;
     file.sync_data()?;
 
-    let dir = std::fs::File::open(".")?;
+    /*
+     * TODO: Support opening directories with `File::open` on Windows.
+    let dir = cap_std::fs::Dir::open(".")?;
     dir.sync_all()?;
     dir.sync_data()?;
+    */
 
     Ok(())
 }

--- a/wasi-common/cap-std-sync/src/file.rs
+++ b/wasi-common/cap-std-sync/src/file.rs
@@ -11,6 +11,8 @@ use wasi_common::{
     file::{Advice, FdFlags, FileType, Filestat, WasiFile},
     Error, ErrorExt,
 };
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED;
 
 pub struct File(cap_std::fs::File);
 
@@ -45,8 +47,17 @@ impl WasiFile for File {
         Ok(())
     }
     async fn sync(&self) -> Result<(), Error> {
-        self.0.sync_all()?;
-        Ok(())
+        match self.0.sync_all() {
+            Ok(()) => Ok(()),
+
+            // On Windows, `sync_all` uses `FlushFileBuffers` which fails
+            // with `ERROR_ACCESS_DENIED` if the file is not open for
+            // writing. Ignore this error, for POSIX compatibility.
+            #[cfg(windows)]
+            Err(e) if e.raw_os_error() == Some(ERROR_ACCESS_DENIED as _) => Ok(()),
+
+            Err(e) => Err(e.into()),
+        }
     }
     async fn get_filetype(&self) -> Result<FileType, Error> {
         let meta = self.0.metadata()?;


### PR DESCRIPTION
On Windows `sync_all` does `FlushFileBuffers` which fails with an access-denied error if the file not opened for writing. Ignore this error, for compatibility with POSIX-style APIs.

Fixes #66.