### PR TITLE
Fill in remaining preview1-based filesystem todos hit by wasi-tests

### DIFF
--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -4,9 +4,9 @@ use crate::wasi_poll::{InputStream, OutputStream};
 use crate::{wasi_filesystem, HostResult, WasiCtx};
 use std::{
     io::{IoSlice, IoSliceMut},
-    ops::BitAnd,
+    ops::{BitAnd, Deref},
     sync::Mutex,
-    time::SystemTime,
+    time::{Duration, SystemTime},
 };
 use wasi_common::{
     dir::{ReaddirCursor, ReaddirIterator, TableDirExt},
@@ -181,6 +181,33 @@ impl From<wasi_common::file::Filestat> for wasi_filesystem::DescriptorStat {
     }
 }
 
+impl From<wasi_filesystem::Advice> for wasi_common::file::Advice {
+    fn from(advice: wasi_filesystem::Advice) -> Self {
+        match advice {
+            wasi_filesystem::Advice::Normal => wasi_common::file::Advice::Normal,
+            wasi_filesystem::Advice::Sequential => wasi_common::file::Advice::Sequential,
+            wasi_filesystem::Advice::Random => wasi_common::file::Advice::Random,
+            wasi_filesystem::Advice::WillNeed => wasi_common::file::Advice::WillNeed,
+            wasi_filesystem::Advice::DontNeed => wasi_common::file::Advice::DontNeed,
+            wasi_filesystem::Advice::NoReuse => wasi_common::file::Advice::NoReuse,
+        }
+    }
+}
+
+fn system_time_spec_from_timestamp(
+    t: wasi_filesystem::NewTimestamp,
+) -> Option<wasi_common::SystemTimeSpec> {
+    match t {
+        wasi_filesystem::NewTimestamp::NoChange => None,
+        wasi_filesystem::NewTimestamp::Now => Some(wasi_common::SystemTimeSpec::SymbolicNow),
+        wasi_filesystem::NewTimestamp::Timestamp(datetime) => Some(
+            wasi_common::SystemTimeSpec::Absolute(cap_std::time::SystemTime::from_std(
+                SystemTime::UNIX_EPOCH + Duration::new(datetime.seconds, datetime.nanoseconds),
+            )),
+        ),
+    }
+}
+
 #[async_trait::async_trait]
 impl wasi_filesystem::WasiFilesystem for WasiCtx {
     async fn fadvise(
@@ -190,7 +217,11 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         len: wasi_filesystem::Filesize,
         advice: wasi_filesystem::Advice,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let f = self.table_mut().get_file_mut(fd).map_err(convert)?;
+        f.advise(offset, len, advice.into())
+            .await
+            .map_err(convert)?;
+        Ok(Ok(()))
     }
 
     async fn datasync(
@@ -276,7 +307,9 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         fd: wasi_filesystem::Descriptor,
         size: wasi_filesystem::Filesize,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let f = self.table_mut().get_file_mut(fd).map_err(convert)?;
+        f.set_filestat_size(size).await.map_err(convert)?;
+        Ok(Ok(()))
     }
 
     async fn set_times(
@@ -285,7 +318,27 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         atim: wasi_filesystem::NewTimestamp,
         mtim: wasi_filesystem::NewTimestamp,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let atim = system_time_spec_from_timestamp(atim);
+        let mtim = system_time_spec_from_timestamp(mtim);
+
+        let table = self.table_mut();
+        if table.is::<Box<dyn WasiFile>>(fd) {
+            Ok(Ok(table
+                .get_file_mut(fd)
+                .expect("checked entry is a file")
+                .set_times(atim, mtim)
+                .await
+                .map_err(convert)?))
+        } else if table.is::<Box<dyn WasiDir>>(fd) {
+            Ok(Ok(table
+                .get_dir(fd)
+                .expect("checked entry is a dir")
+                .set_times(".", atim, mtim, false)
+                .await
+                .map_err(convert)?))
+        } else {
+            Err(wasi_filesystem::Errno::Badf.into())
+        }
     }
 
     async fn pread(
@@ -465,18 +518,40 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         atim: wasi_filesystem::NewTimestamp,
         mtim: wasi_filesystem::NewTimestamp,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        Ok(Ok(table
+            .get_dir(fd)
+            .map_err(convert)?
+            .set_times(
+                &path,
+                system_time_spec_from_timestamp(atim),
+                system_time_spec_from_timestamp(mtim),
+                contains(at_flags, wasi_filesystem::AtFlags::SYMLINK_FOLLOW),
+            )
+            .await
+            .map_err(convert)?))
     }
 
     async fn link_at(
         &mut self,
         fd: wasi_filesystem::Descriptor,
+        // TODO delete the at flags from this function
         old_at_flags: wasi_filesystem::AtFlags,
         old_path: String,
         new_descriptor: wasi_filesystem::Descriptor,
         new_path: String,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        let old_dir = table.get_dir(fd).map_err(convert)?;
+        let new_dir = table.get_dir(new_descriptor).map_err(convert)?;
+        if contains(old_at_flags, wasi_filesystem::AtFlags::SYMLINK_FOLLOW) {
+            return Ok(Err(wasi_filesystem::Errno::Inval));
+        }
+        old_dir
+            .hard_link(&old_path, new_dir.deref(), &new_path)
+            .await
+            .map_err(convert)?;
+        Ok(Ok(()))
     }
 
     async fn open_at(
@@ -541,7 +616,13 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         fd: wasi_filesystem::Descriptor,
         path: String,
     ) -> HostResult<String, wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        let dir = table.get_dir(fd).map_err(convert)?;
+        let link = dir.read_link(&path).await.map_err(convert)?;
+        Ok(link
+            .into_os_string()
+            .into_string()
+            .map_err(|_| wasi_filesystem::Errno::Ilseq))
     }
 
     async fn remove_directory_at(
@@ -565,7 +646,14 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         new_fd: wasi_filesystem::Descriptor,
         new_path: String,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        let table = self.table();
+        let old_dir = table.get_dir(fd).map_err(convert)?;
+        let new_dir = table.get_dir(new_fd).map_err(convert)?;
+        old_dir
+            .rename(&old_path, new_dir.deref(), &new_path)
+            .await
+            .map_err(convert)?;
+        Ok(Ok(()))
     }
 
     async fn symlink_at(

--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -299,7 +299,8 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         fd: wasi_filesystem::Descriptor,
         flags: wasi_filesystem::DescriptorFlags,
     ) -> HostResult<(), wasi_filesystem::Errno> {
-        todo!()
+        // FIXME
+        Err(wasi_filesystem::Errno::Notsup.into())
     }
 
     async fn set_size(

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -510,10 +510,6 @@ async fn run_fd_filestat_get(store: Store<WasiCtx>, wasi: WasiCommand) -> Result
 }
 
 async fn run_fd_filestat_set(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 
@@ -641,10 +637,6 @@ async fn run_path_rename_dir_trailing_slashes(
     store: Store<WasiCtx>,
     wasi: WasiCommand,
 ) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 
@@ -731,10 +723,6 @@ async fn run_symlink_create(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<
 }
 
 async fn run_symlink_filestat(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
     run_with_temp_dir(store, wasi).await
 }
 

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -20,13 +20,16 @@ use wasmtime::{
 
 test_programs_macros::tests!();
 
-// FIXME: a bunch of these test cases are expected to fail, either by
-// returning an Err or by panicking. Rather than try to juggle the
-// intersection of catch_unwind and async, we use this boolean to
-// short-circuit a bunch of tests expected to blow up. Developers may change
-// this redefintion to `false` locally  to see if any of the failing tests
-// start passing as you add functionality.
-const EXPECT_FAIL: bool = true;
+// A bunch of these test cases are expected to fail. We wrap up their execution in this
+// function so that we see if changes make them start passing.
+// Note that we need to be careful not to check in any tests that panic for this approach
+// to work.
+fn expect_fail(r: Result<()>) -> Result<()> {
+    match r {
+        Ok(_) => Err(anyhow::anyhow!("expected failure")),
+        Err(_) => Ok(()),
+    }
+}
 
 async fn instantiate(path: &str) -> Result<(Store<WasiCtx>, WasiCommand)> {
     println!("{}", path);
@@ -462,51 +465,31 @@ async fn run_clock_time_get(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<
 }
 
 async fn run_close_preopen(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_dangling_fd(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL && cfg!(windows) {
-        // TODO!
-        return Ok(());
+    if cfg!(windows) {
+        expect_fail(run_with_temp_dir(store, wasi).await)
+    } else {
+        run_with_temp_dir(store, wasi).await
     }
-    run_with_temp_dir(store, wasi).await
 }
 
 async fn run_dangling_symlink(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_directory_seek(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_fd_advise(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_fd_filestat_get(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_fd_filestat_set(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -514,11 +497,7 @@ async fn run_fd_filestat_set(store: Store<WasiCtx>, wasi: WasiCommand) -> Result
 }
 
 async fn run_fd_flags_set(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_fd_readdir(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -526,11 +505,7 @@ async fn run_fd_readdir(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> 
 }
 
 async fn run_file_allocate(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_file_pread_pwrite(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -538,11 +513,7 @@ async fn run_file_pread_pwrite(store: Store<WasiCtx>, wasi: WasiCommand) -> Resu
 }
 
 async fn run_file_seek_tell(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_file_truncation(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -554,11 +525,7 @@ async fn run_file_unbuffered_write(store: Store<WasiCtx>, wasi: WasiCommand) -> 
 }
 
 async fn run_interesting_paths(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_isatty(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -566,11 +533,7 @@ async fn run_isatty(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
 }
 
 async fn run_nofollow_errors(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_path_exists(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -578,59 +541,31 @@ async fn run_path_exists(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()>
 }
 
 async fn run_path_filestat(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_path_link(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_path_open_create_existing(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_path_open_dirfd_not_dir(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_path_open_missing(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_path_open_read_without_rights(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_path_rename(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_path_rename_dir_trailing_slashes(
@@ -644,70 +579,38 @@ async fn run_path_rename_file_trailing_slashes(
     store: Store<WasiCtx>,
     wasi: WasiCommand,
 ) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_path_symlink_trailing_slashes(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_poll_oneoff_files(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_poll_oneoff_stdio(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_readlink(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_remove_directory_trailing_slashes(
     store: Store<WasiCtx>,
     wasi: WasiCommand,
 ) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_remove_nonempty_directory(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_renumber(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_sched_yield(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -727,25 +630,13 @@ async fn run_symlink_filestat(store: Store<WasiCtx>, wasi: WasiCommand) -> Resul
 }
 
 async fn run_symlink_loop(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_truncation_rights(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }
 
 async fn run_unlink_file_trailing_slashes(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    if EXPECT_FAIL {
-        // TODO!
-        return Ok(());
-    }
-    run_with_temp_dir(store, wasi).await
+    expect_fail(run_with_temp_dir(store, wasi).await)
 }


### PR DESCRIPTION
This fills in all of the `todo!()` macros hit by the execution of wasi-tests.

I put in a plausible implementation for all but `set_flags`, which requires some design work.

Three additional tests now pass:
* fd_filestat_set
* path_rename_dir_trailing_slashes
* symlink_filestat

And, best of all, since none of the tests panic anymore, I could replace the `EXPECT_FAIL` short-circuit with a function `expect_fail(Result<()>) -> Result<()>`, so we can automatically find out when failing tests start passing.