### PR TITLE
Rename `wasi-future` to `waitable`.

### DIFF
--- a/host/src/poll.rs
+++ b/host/src/poll.rs
@@ -1,6 +1,6 @@
 use crate::{
     wasi_clocks,
-    wasi_poll::{self, Size, StreamError, WasiFuture, WasiPoll, WasiStream},
+    wasi_poll::{self, Size, StreamError, Waitable, WasiPoll, WasiStream},
     HostResult, WasiCtx,
 };
 use wasi_common::clocks::TableMonotonicClockExt;
@@ -14,9 +14,9 @@ fn convert(error: wasi_common::Error) -> anyhow::Error {
     }
 }
 
-/// A pseudo-future representation.
+/// A waitable resource table entry.
 #[derive(Copy, Clone)]
-enum Future {
+enum WaitableEntry {
     /// Poll for read events.
     Read(WasiStream),
     /// Poll for write events.
@@ -27,12 +27,14 @@ enum Future {
 
 #[async_trait::async_trait]
 impl WasiPoll for WasiCtx {
-    async fn drop_future(&mut self, future: WasiFuture) -> anyhow::Result<()> {
-        self.table_mut().delete::<Future>(future).map_err(convert)?;
+    async fn drop_waitable(&mut self, waitable: Waitable) -> anyhow::Result<()> {
+        self.table_mut()
+            .delete::<WaitableEntry>(waitable)
+            .map_err(convert)?;
         Ok(())
     }
 
-    async fn poll_oneoff(&mut self, futures: Vec<WasiFuture>) -> anyhow::Result<Vec<u8>> {
+    async fn poll_oneoff(&mut self, futures: Vec<Waitable>) -> anyhow::Result<Vec<u8>> {
         use wasi_common::sched::{Poll, Userdata};
 
         // Convert `futures` into `Poll` subscriptions.
@@ -40,17 +42,17 @@ impl WasiPoll for WasiCtx {
         let len = futures.len();
         for (index, future) in futures.into_iter().enumerate() {
             match *self.table().get(future).map_err(convert)? {
-                Future::Read(stream) => {
+                WaitableEntry::Read(stream) => {
                     let wasi_stream: &dyn wasi_common::WasiStream =
                         self.table().get_stream(stream).map_err(convert)?;
                     poll.subscribe_read(wasi_stream, Userdata::from(index as u64));
                 }
-                Future::Write(stream) => {
+                WaitableEntry::Write(stream) => {
                     let wasi_stream: &dyn wasi_common::WasiStream =
                         self.table().get_stream(stream).map_err(convert)?;
                     poll.subscribe_write(wasi_stream, Userdata::from(index as u64));
                 }
-                Future::MonotonicClock(clock, when, absolute) => {
+                WaitableEntry::MonotonicClock(clock, when, absolute) => {
                     let wasi_clock = self.table().get_monotonic_clock(clock).map_err(convert)?;
                     poll.subscribe_monotonic_clock(
                         wasi_clock,
@@ -167,12 +169,16 @@ impl WasiPoll for WasiCtx {
         todo!()
     }
 
-    async fn subscribe_read(&mut self, stream: WasiStream) -> anyhow::Result<WasiFuture> {
-        Ok(self.table_mut().push(Box::new(Future::Read(stream)))?)
+    async fn subscribe_read(&mut self, stream: WasiStream) -> anyhow::Result<Waitable> {
+        Ok(self
+            .table_mut()
+            .push(Box::new(WaitableEntry::Read(stream)))?)
     }
 
-    async fn subscribe_write(&mut self, stream: WasiStream) -> anyhow::Result<WasiFuture> {
-        Ok(self.table_mut().push(Box::new(Future::Write(stream)))?)
+    async fn subscribe_write(&mut self, stream: WasiStream) -> anyhow::Result<Waitable> {
+        Ok(self
+            .table_mut()
+            .push(Box::new(WaitableEntry::Write(stream)))?)
     }
 
     async fn subscribe_monotonic_clock(
@@ -180,9 +186,11 @@ impl WasiPoll for WasiCtx {
         clock: wasi_clocks::MonotonicClock,
         when: wasi_clocks::Instant,
         absolute: bool,
-    ) -> anyhow::Result<WasiFuture> {
+    ) -> anyhow::Result<Waitable> {
         Ok(self
             .table_mut()
-            .push(Box::new(Future::MonotonicClock(clock, when, absolute)))?)
+            .push(Box::new(WaitableEntry::MonotonicClock(
+                clock, when, absolute,
+            )))?)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use core::mem::{align_of, forget, replace, size_of, ManuallyDrop, MaybeUninit};
 use core::ptr::{self, null_mut};
 use core::slice;
 use wasi::*;
-use wasi_poll::{Waitable, WasiStream};
+use wasi_poll::{Pollable, WasiStream};
 
 #[macro_use]
 mod macros;
@@ -1408,24 +1408,24 @@ pub unsafe extern "C" fn path_unlink_file(fd: Fd, path_ptr: *const u8, path_len:
     })
 }
 
-struct Waitables {
-    pointer: *mut Waitable,
+struct Pollables {
+    pointer: *mut Pollable,
     index: usize,
     length: usize,
 }
 
-impl Waitables {
-    unsafe fn push(&mut self, waitable: Waitable) {
+impl Pollables {
+    unsafe fn push(&mut self, pollable: Pollable) {
         assert!(self.index < self.length);
-        *self.pointer.add(self.index) = waitable;
+        *self.pointer.add(self.index) = pollable;
         self.index += 1;
     }
 }
 
-impl Drop for Waitables {
+impl Drop for Pollables {
     fn drop(&mut self) {
         for i in 0..self.index {
-            wasi_poll::drop_waitable(unsafe { *self.pointer.add(i) })
+            wasi_poll::drop_pollable(unsafe { *self.pointer.add(i) })
         }
     }
 }
@@ -1461,23 +1461,23 @@ pub unsafe extern "C" fn poll_oneoff(
     let subscriptions = slice::from_raw_parts(r#in, nsubscriptions);
 
     // We're going to split the `nevents` buffer into two non-overlapping
-    // buffers: one to store the waitable handles, and the other to store
+    // buffers: one to store the pollable handles, and the other to store
     // the bool results.
     //
     // First, we assert that this is possible:
-    assert!(align_of::<Event>() >= align_of::<Waitable>());
-    assert!(align_of::<Waitable>() >= align_of::<u8>());
+    assert!(align_of::<Event>() >= align_of::<Pollable>());
+    assert!(align_of::<Pollable>() >= align_of::<u8>());
     assert!(
         unwrap(nsubscriptions.checked_mul(size_of::<Event>()))
             >= unwrap(
-                unwrap(nsubscriptions.checked_mul(size_of::<Waitable>()))
+                unwrap(nsubscriptions.checked_mul(size_of::<Pollable>()))
                     .checked_add(unwrap(nsubscriptions.checked_mul(size_of::<u8>())))
             )
     );
 
-    // Store the waitable handles at the beginning, and the bool results at the
+    // Store the pollable handles at the beginning, and the bool results at the
     // end, so that we don't clobber the bool results when writting the events.
-    let waitables = out as *mut c_void as *mut Waitable;
+    let pollables = out as *mut c_void as *mut Pollable;
     let results = out.add(nsubscriptions).cast::<u8>().sub(nsubscriptions);
 
     // Indefinite sleeping is not supported in preview1.
@@ -1491,8 +1491,8 @@ pub unsafe extern "C" fn poll_oneoff(
             unwrap(nsubscriptions.checked_mul(size_of::<bool>())),
         );
 
-        let mut waitables = Waitables {
-            pointer: waitables,
+        let mut pollables = Pollables {
+            pointer: pollables,
             index: 0,
             length: nsubscriptions,
         };
@@ -1501,7 +1501,7 @@ pub unsafe extern "C" fn poll_oneoff(
             const EVENTTYPE_CLOCK: u8 = wasi::EVENTTYPE_CLOCK.raw();
             const EVENTTYPE_FD_READ: u8 = wasi::EVENTTYPE_FD_READ.raw();
             const EVENTTYPE_FD_WRITE: u8 = wasi::EVENTTYPE_FD_WRITE.raw();
-            waitables.push(match subscription.u.tag {
+            pollables.push(match subscription.u.tag {
                 EVENTTYPE_CLOCK => {
                     let clock = &subscription.u.u.clock;
                     let absolute = (clock.flags & SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME)
@@ -1557,7 +1557,7 @@ pub unsafe extern "C" fn poll_oneoff(
                     match state.get_read_stream(subscription.u.u.fd_read.file_descriptor) {
                         Ok(stream) => wasi_poll::subscribe_read(stream),
                         // If the file descriptor isn't a stream, request a
-                        // waitable which completes immediately so that it'll
+                        // pollable which completes immediately so that it'll
                         // immediately fail.
                         Err(ERRNO_BADF) => wasi_poll::subscribe_monotonic_clock(
                             state.default_monotonic_clock(),
@@ -1572,7 +1572,7 @@ pub unsafe extern "C" fn poll_oneoff(
                     match state.get_write_stream(subscription.u.u.fd_write.file_descriptor) {
                         Ok(stream) => wasi_poll::subscribe_write(stream),
                         // If the file descriptor isn't a stream, request a
-                        // waitable which completes immediately so that it'll
+                        // pollable which completes immediately so that it'll
                         // immediately fail.
                         Err(ERRNO_BADF) => wasi_poll::subscribe_monotonic_clock(
                             state.default_monotonic_clock(),
@@ -1588,13 +1588,13 @@ pub unsafe extern "C" fn poll_oneoff(
         }
 
         let vec =
-            wasi_poll::poll_oneoff(slice::from_raw_parts(waitables.pointer, waitables.length));
+            wasi_poll::poll_oneoff(slice::from_raw_parts(pollables.pointer, pollables.length));
 
         assert_eq!(vec.len(), nsubscriptions);
         assert_eq!(vec.as_ptr(), results);
         forget(vec);
 
-        drop(waitables);
+        drop(pollables);
 
         let ready = subscriptions
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use core::mem::{align_of, forget, replace, size_of, ManuallyDrop, MaybeUninit};
 use core::ptr::{self, null_mut};
 use core::slice;
 use wasi::*;
-use wasi_poll::{WasiFuture, WasiStream};
+use wasi_poll::{Waitable, WasiStream};
 
 #[macro_use]
 mod macros;
@@ -1408,24 +1408,24 @@ pub unsafe extern "C" fn path_unlink_file(fd: Fd, path_ptr: *const u8, path_len:
     })
 }
 
-struct Futures {
-    pointer: *mut WasiFuture,
+struct Waitables {
+    pointer: *mut Waitable,
     index: usize,
     length: usize,
 }
 
-impl Futures {
-    unsafe fn push(&mut self, future: WasiFuture) {
+impl Waitables {
+    unsafe fn push(&mut self, waitable: Waitable) {
         assert!(self.index < self.length);
-        *self.pointer.add(self.index) = future;
+        *self.pointer.add(self.index) = waitable;
         self.index += 1;
     }
 }
 
-impl Drop for Futures {
+impl Drop for Waitables {
     fn drop(&mut self) {
         for i in 0..self.index {
-            wasi_poll::drop_future(unsafe { *self.pointer.add(i) })
+            wasi_poll::drop_waitable(unsafe { *self.pointer.add(i) })
         }
     }
 }
@@ -1460,23 +1460,24 @@ pub unsafe extern "C" fn poll_oneoff(
 
     let subscriptions = slice::from_raw_parts(r#in, nsubscriptions);
 
-    // We're going to split the `nevents` buffer into two non-overlapping buffers: one to store the future handles,
-    // and the other to store the bool results.
+    // We're going to split the `nevents` buffer into two non-overlapping
+    // buffers: one to store the waitable handles, and the other to store
+    // the bool results.
     //
     // First, we assert that this is possible:
-    assert!(align_of::<Event>() >= align_of::<WasiFuture>());
-    assert!(align_of::<WasiFuture>() >= align_of::<u8>());
+    assert!(align_of::<Event>() >= align_of::<Waitable>());
+    assert!(align_of::<Waitable>() >= align_of::<u8>());
     assert!(
         unwrap(nsubscriptions.checked_mul(size_of::<Event>()))
             >= unwrap(
-                unwrap(nsubscriptions.checked_mul(size_of::<WasiFuture>()))
+                unwrap(nsubscriptions.checked_mul(size_of::<Waitable>()))
                     .checked_add(unwrap(nsubscriptions.checked_mul(size_of::<u8>())))
             )
     );
 
-    // Store the future handles at the beginning, and the bool results at the
+    // Store the waitable handles at the beginning, and the bool results at the
     // end, so that we don't clobber the bool results when writting the events.
-    let futures = out as *mut c_void as *mut WasiFuture;
+    let waitables = out as *mut c_void as *mut Waitable;
     let results = out.add(nsubscriptions).cast::<u8>().sub(nsubscriptions);
 
     // Indefinite sleeping is not supported in preview1.
@@ -1490,8 +1491,8 @@ pub unsafe extern "C" fn poll_oneoff(
             unwrap(nsubscriptions.checked_mul(size_of::<bool>())),
         );
 
-        let mut futures = Futures {
-            pointer: futures,
+        let mut waitables = Waitables {
+            pointer: waitables,
             index: 0,
             length: nsubscriptions,
         };
@@ -1500,7 +1501,7 @@ pub unsafe extern "C" fn poll_oneoff(
             const EVENTTYPE_CLOCK: u8 = wasi::EVENTTYPE_CLOCK.raw();
             const EVENTTYPE_FD_READ: u8 = wasi::EVENTTYPE_FD_READ.raw();
             const EVENTTYPE_FD_WRITE: u8 = wasi::EVENTTYPE_FD_WRITE.raw();
-            futures.push(match subscription.u.tag {
+            waitables.push(match subscription.u.tag {
                 EVENTTYPE_CLOCK => {
                     let clock = &subscription.u.u.clock;
                     let absolute = (clock.flags & SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME)
@@ -1556,7 +1557,7 @@ pub unsafe extern "C" fn poll_oneoff(
                     match state.get_read_stream(subscription.u.u.fd_read.file_descriptor) {
                         Ok(stream) => wasi_poll::subscribe_read(stream),
                         // If the file descriptor isn't a stream, request a
-                        // future which completes immediately so that it'll
+                        // waitable which completes immediately so that it'll
                         // immediately fail.
                         Err(ERRNO_BADF) => wasi_poll::subscribe_monotonic_clock(
                             state.default_monotonic_clock(),
@@ -1571,7 +1572,7 @@ pub unsafe extern "C" fn poll_oneoff(
                     match state.get_write_stream(subscription.u.u.fd_write.file_descriptor) {
                         Ok(stream) => wasi_poll::subscribe_write(stream),
                         // If the file descriptor isn't a stream, request a
-                        // future which completes immediately so that it'll
+                        // waitable which completes immediately so that it'll
                         // immediately fail.
                         Err(ERRNO_BADF) => wasi_poll::subscribe_monotonic_clock(
                             state.default_monotonic_clock(),
@@ -1586,13 +1587,14 @@ pub unsafe extern "C" fn poll_oneoff(
             });
         }
 
-        let vec = wasi_poll::poll_oneoff(slice::from_raw_parts(futures.pointer, futures.length));
+        let vec =
+            wasi_poll::poll_oneoff(slice::from_raw_parts(waitables.pointer, waitables.length));
 
         assert_eq!(vec.len(), nsubscriptions);
         assert_eq!(vec.as_ptr(), results);
         forget(vec);
 
-        drop(futures);
+        drop(waitables);
 
         let ready = subscriptions
             .iter()

--- a/wit/wasi-clocks.wit
+++ b/wit/wasi-clocks.wit
@@ -30,10 +30,10 @@ default interface wasi-clocks {
       nanoseconds: u32,
   }
 
-  /// An asynchronous operation. See the comments on `waitable` in the
+  /// An asynchronous operation. See the comments on `pollable` in the
   /// `wasi-poll` interface for details.
   /// TODO: `use` the `wasi-poll` version
-  type waitable = u32
+  type pollable = u32
 
   /// Read the current value of the clock.
   ///

--- a/wit/wasi-clocks.wit
+++ b/wit/wasi-clocks.wit
@@ -30,10 +30,10 @@ default interface wasi-clocks {
       nanoseconds: u32,
   }
 
-  /// An asynchronous operation. See the comments on `wasi-future` in the
+  /// An asynchronous operation. See the comments on `waitable` in the
   /// `wasi-poll` interface for details.
   /// TODO: `use` the `wasi-poll` version
-  type wasi-future = u32
+  type waitable = u32
 
   /// Read the current value of the clock.
   ///

--- a/wit/wasi-poll.wit
+++ b/wit/wasi-poll.wit
@@ -5,29 +5,31 @@
 default interface wasi-poll {
   use pkg.wasi-clocks.{wall-clock, monotonic-clock, datetime, instant}
 
-  /// A "pseudo-future".
+  /// A "waitable" handle.
   ///
-  /// This conceptually represents a `future<_>`, and serves as temporary
-  /// scaffolding until component-model's async features are ready.
+  /// This is conceptually represents a `stream<_, _>`, or in other words,
+  /// a stream that one can wait on, repeatedly, but which does not itself
+  /// produce any data. It's temporary scaffolding until component-model's
+  /// async features are ready.
   ///
-  /// In the shorter term, it is a `u32` which will be replaced by a handle
-  /// when the component-model handles and resource features are ready.
+  /// And at present, it is a `u32` instead of being an actual handle, until
+  /// the wit-bindgen implementation of handles and resources is ready.
   ///
-  /// Pseudo-future lifetimes are not automatically managed. Users must
-  /// ensure that they do not outlive the resource they reference.
-  type wasi-future = u32
+  /// Waitable lifetimes are not automatically managed. Users must ensure
+  /// that they do not outlive the resource they reference.
+  type waitable = u32
 
-  /// A "pseudo-stream".
+  /// A "bytestream" handle.
   ///
-  /// This conceptually represents a `stream<u8, _>`, and serves as temporary
+  /// This conceptually represents a `stream<u8, _>`. It's temporary
   /// scaffolding until component-model's async features are ready.
   ///
-  /// In the shorter term, it is a `u32` which will be replaced by a handle
-  /// when the component-model handles and resource features are ready.
+  /// And at present, it is a `u32` instead of being an actual handle, until
+  /// the wit-bindgen implementation of handles and resources is ready.
   type wasi-stream = u32
 
-  /// Dispose of the specified future, after which it may no longer be used.
-  drop-future: func(f: wasi-future)
+  /// Dispose of the specified `waitable`, after which it may no longer be used.
+  drop-waitable: func(f: waitable)
 
   /// Dispose of the specified stream, after which it may no longer be used.
   drop-stream: func(f: wasi-stream)
@@ -83,18 +85,18 @@ default interface wasi-poll {
       len: u64,
   ) -> result<tuple<u64, bool>, stream-error>
 
-  /// Create a future which will resolve once either the specified stream has bytes
+  /// Create a `waitable` which will resolve once either the specified stream has bytes
   /// available to read or the other end of the stream has been closed.
-  subscribe-read: func(s: wasi-stream) -> wasi-future
+  subscribe-read: func(s: wasi-stream) -> waitable
 
-  /// Create a future which will resolve once either the specified stream is ready
+  /// Create a `waitable` which will resolve once either the specified stream is ready
   /// to accept bytes or the other end of the stream has been closed.
-  subscribe-write: func(s: wasi-stream) -> wasi-future
+  subscribe-write: func(s: wasi-stream) -> waitable
 
-  /// Create a future which will resolve once the specified time has been reached.
-  subscribe-monotonic-clock: func(clock: monotonic-clock, when: instant, absolute: bool) -> wasi-future
+  /// Create a `waitable` which will resolve once the specified time has been reached.
+  subscribe-monotonic-clock: func(clock: monotonic-clock, when: instant, absolute: bool) -> waitable
 
-  /// Poll for completion on a set of futures.
+  /// Poll for completion on a set of waitables.
   ///
   /// The "oneoff" in the name refers to the fact that this function must do a
   /// linear scan through the entire list of subscriptions, which may be
@@ -108,5 +110,5 @@ default interface wasi-poll {
   /// See https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061
   /// for details.  For now, we use zero to mean "not ready" and non-zero to
   /// mean "ready".
-  poll-oneoff: func(in: list<wasi-future>) -> list<u8>
+  poll-oneoff: func(in: list<waitable>) -> list<u8>
 }

--- a/wit/wasi-poll.wit
+++ b/wit/wasi-poll.wit
@@ -5,7 +5,7 @@
 default interface wasi-poll {
   use pkg.wasi-clocks.{wall-clock, monotonic-clock, datetime, instant}
 
-  /// A "waitable" handle.
+  /// A "pollable" handle.
   ///
   /// This is conceptually represents a `stream<_, _>`, or in other words,
   /// a stream that one can wait on, repeatedly, but which does not itself
@@ -17,7 +17,7 @@ default interface wasi-poll {
   ///
   /// Waitable lifetimes are not automatically managed. Users must ensure
   /// that they do not outlive the resource they reference.
-  type waitable = u32
+  type pollable = u32
 
   /// A "bytestream" handle.
   ///
@@ -28,8 +28,8 @@ default interface wasi-poll {
   /// the wit-bindgen implementation of handles and resources is ready.
   type wasi-stream = u32
 
-  /// Dispose of the specified `waitable`, after which it may no longer be used.
-  drop-waitable: func(f: waitable)
+  /// Dispose of the specified `pollable`, after which it may no longer be used.
+  drop-pollable: func(f: pollable)
 
   /// Dispose of the specified stream, after which it may no longer be used.
   drop-stream: func(f: wasi-stream)
@@ -85,18 +85,18 @@ default interface wasi-poll {
       len: u64,
   ) -> result<tuple<u64, bool>, stream-error>
 
-  /// Create a `waitable` which will resolve once either the specified stream has bytes
+  /// Create a `pollable` which will resolve once either the specified stream has bytes
   /// available to read or the other end of the stream has been closed.
-  subscribe-read: func(s: wasi-stream) -> waitable
+  subscribe-read: func(s: wasi-stream) -> pollable
 
-  /// Create a `waitable` which will resolve once either the specified stream is ready
+  /// Create a `pollable` which will resolve once either the specified stream is ready
   /// to accept bytes or the other end of the stream has been closed.
-  subscribe-write: func(s: wasi-stream) -> waitable
+  subscribe-write: func(s: wasi-stream) -> pollable
 
-  /// Create a `waitable` which will resolve once the specified time has been reached.
-  subscribe-monotonic-clock: func(clock: monotonic-clock, when: instant, absolute: bool) -> waitable
+  /// Create a `pollable` which will resolve once the specified time has been reached.
+  subscribe-monotonic-clock: func(clock: monotonic-clock, when: instant, absolute: bool) -> pollable
 
-  /// Poll for completion on a set of waitables.
+  /// Poll for completion on a set of pollables.
   ///
   /// The "oneoff" in the name refers to the fact that this function must do a
   /// linear scan through the entire list of subscriptions, which may be
@@ -110,5 +110,5 @@ default interface wasi-poll {
   /// See https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061
   /// for details.  For now, we use zero to mean "not ready" and non-zero to
   /// mean "ready".
-  poll-oneoff: func(in: list<waitable>) -> list<u8>
+  poll-oneoff: func(in: list<pollable>) -> list<u8>
 }

--- a/wit/wasi-tcp.wit
+++ b/wit/wasi-tcp.wit
@@ -1,5 +1,5 @@
 default interface wasi-tcp {
-  use pkg.wasi-poll.{wasi-future}
+  use pkg.wasi-poll.{waitable}
 
   /// A socket pseudo-handle. In the future, this will be replaced by a handle type.
   type socket = u32

--- a/wit/wasi-tcp.wit
+++ b/wit/wasi-tcp.wit
@@ -1,5 +1,5 @@
 default interface wasi-tcp {
-  use pkg.wasi-poll.{waitable}
+  use pkg.wasi-poll.{pollable}
 
   /// A socket pseudo-handle. In the future, this will be replaced by a handle type.
   type socket = u32


### PR DESCRIPTION
You can wait on `waitable`s multiple times, which differs from proper futures, which you can only wait on once.