### PR TITLE
Fix the non-command build

### DIFF
--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -1,0 +1,11 @@
+default world wasi {
+  import wasi-clocks: pkg.wasi-clocks
+  import wasi-default-clocks: pkg.wasi-clocks.wasi-default-clocks
+  import wasi-logging: pkg.wasi-logging
+  import wasi-stderr: pkg.wasi-stderr
+  import wasi-filesystem: pkg.wasi-filesystem
+  import wasi-random: pkg.wasi-random
+  import wasi-poll: pkg.wasi-poll
+  import wasi-tcp: pkg.wasi-tcp
+  import wasi-exit: pkg.wasi-exit
+}


### PR DESCRIPTION
This commit fixes the non-command build of the WASI adapter by adding a new `wasi.wit` which only has the imports and nothing else.