### PR TITLE
Split wasi-stream into separate input and output stream types.

### DIFF
--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
 
-use crate::wasi_poll::WasiStream;
+use crate::wasi_poll::{InputStream, OutputStream};
 use crate::{wasi_filesystem, HostResult, WasiCtx};
 use std::{
     io::{IoSlice, IoSliceMut},
@@ -656,7 +656,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         &mut self,
         fd: wasi_filesystem::Descriptor,
         offset: wasi_filesystem::Filesize,
-    ) -> HostResult<WasiStream, wasi_filesystem::Errno> {
+    ) -> HostResult<InputStream, wasi_filesystem::Errno> {
         let f = self.table_mut().get_file_mut(fd).map_err(convert)?;
 
         // Duplicate the file descriptor so that we get an indepenent lifetime.
@@ -666,7 +666,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         let reader = FileStream::new_reader(clone, offset);
 
         // Box it up.
-        let boxed: Box<dyn wasi_common::WasiStream> = Box::new(reader);
+        let boxed: Box<dyn wasi_common::InputStream> = Box::new(reader);
 
         // Insert the stream view into the table.
         let index = self.table_mut().push(Box::new(boxed)).map_err(convert)?;
@@ -678,7 +678,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         &mut self,
         fd: wasi_filesystem::Descriptor,
         offset: wasi_filesystem::Filesize,
-    ) -> HostResult<WasiStream, wasi_filesystem::Errno> {
+    ) -> HostResult<OutputStream, wasi_filesystem::Errno> {
         let f = self.table_mut().get_file_mut(fd).map_err(convert)?;
 
         // Duplicate the file descriptor so that we get an indepenent lifetime.
@@ -688,7 +688,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         let writer = FileStream::new_writer(clone, offset);
 
         // Box it up.
-        let boxed: Box<dyn wasi_common::WasiStream> = Box::new(writer);
+        let boxed: Box<dyn wasi_common::OutputStream> = Box::new(writer);
 
         // Insert the stream view into the table.
         let index = self.table_mut().push(Box::new(boxed)).map_err(convert)?;
@@ -699,7 +699,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
     async fn append_via_stream(
         &mut self,
         fd: wasi_filesystem::Descriptor,
-    ) -> HostResult<WasiStream, wasi_filesystem::Errno> {
+    ) -> HostResult<OutputStream, wasi_filesystem::Errno> {
         let f = self.table_mut().get_file_mut(fd).map_err(convert)?;
 
         // Duplicate the file descriptor so that we get an indepenent lifetime.
@@ -709,7 +709,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         let appender = FileStream::new_appender(clone);
 
         // Box it up.
-        let boxed: Box<dyn wasi_common::WasiStream> = Box::new(appender);
+        let boxed: Box<dyn wasi_common::OutputStream> = Box::new(appender);
 
         // Insert the stream view into the table.
         let index = self.table_mut().push(Box::new(boxed)).map_err(convert)?;

--- a/host/src/io.rs
+++ b/host/src/io.rs
@@ -1,0 +1,154 @@
+use crate::{
+    wasi_io::{InputStream, OutputStream, StreamError, WasiIo},
+    HostResult, WasiCtx,
+};
+use wasi_common::stream::TableStreamExt;
+
+fn convert(error: wasi_common::Error) -> anyhow::Error {
+    if let Some(_errno) = error.downcast_ref() {
+        anyhow::Error::new(StreamError {})
+    } else {
+        error.into()
+    }
+}
+
+#[async_trait::async_trait]
+impl WasiIo for WasiCtx {
+    async fn drop_input_stream(&mut self, stream: InputStream) -> anyhow::Result<()> {
+        self.table_mut()
+            .delete::<Box<dyn wasi_common::InputStream>>(stream)
+            .map_err(convert)?;
+        Ok(())
+    }
+
+    async fn drop_output_stream(&mut self, stream: OutputStream) -> anyhow::Result<()> {
+        self.table_mut()
+            .delete::<Box<dyn wasi_common::OutputStream>>(stream)
+            .map_err(convert)?;
+        Ok(())
+    }
+
+    async fn read(
+        &mut self,
+        stream: InputStream,
+        len: u64,
+    ) -> HostResult<(Vec<u8>, bool), StreamError> {
+        let s: &mut Box<dyn wasi_common::InputStream> = self
+            .table_mut()
+            .get_input_stream_mut(stream)
+            .map_err(convert)?;
+
+        let mut buffer = vec![0; len.try_into().unwrap()];
+
+        let (bytes_read, end) = s.read(&mut buffer).await.map_err(convert)?;
+
+        buffer.truncate(bytes_read as usize);
+
+        Ok(Ok((buffer, end)))
+    }
+
+    async fn write(
+        &mut self,
+        stream: OutputStream,
+        bytes: Vec<u8>,
+    ) -> HostResult<u64, StreamError> {
+        let s: &mut Box<dyn wasi_common::OutputStream> = self
+            .table_mut()
+            .get_output_stream_mut(stream)
+            .map_err(convert)?;
+
+        let bytes_written: u64 = s.write(&bytes).await.map_err(convert)?;
+
+        Ok(Ok(u64::try_from(bytes_written).unwrap()))
+    }
+
+    async fn skip(
+        &mut self,
+        stream: InputStream,
+        len: u64,
+    ) -> HostResult<(u64, bool), StreamError> {
+        let s: &mut Box<dyn wasi_common::InputStream> = self
+            .table_mut()
+            .get_input_stream_mut(stream)
+            .map_err(convert)?;
+
+        let (bytes_skipped, end) = s.skip(len).await.map_err(convert)?;
+
+        Ok(Ok((bytes_skipped, end)))
+    }
+
+    async fn write_repeated(
+        &mut self,
+        stream: OutputStream,
+        byte: u8,
+        len: u64,
+    ) -> HostResult<u64, StreamError> {
+        let s: &mut Box<dyn wasi_common::OutputStream> = self
+            .table_mut()
+            .get_output_stream_mut(stream)
+            .map_err(convert)?;
+
+        let bytes_written: u64 = s.write_repeated(byte, len).await.map_err(convert)?;
+
+        Ok(Ok(bytes_written))
+    }
+
+    async fn splice(
+        &mut self,
+        _src: InputStream,
+        _dst: OutputStream,
+        _len: u64,
+    ) -> HostResult<(u64, bool), StreamError> {
+        // TODO: We can't get two streams at the same time because they both
+        // carry the exclusive lifetime of `self`. When [`get_many_mut`] is
+        // stabilized, that could allow us to add a `get_many_stream_mut` or
+        // so which lets us do this.
+        //
+        // [`get_many_mut`]: https://doc.rust-lang.org/stable/std/collections/hash_map/struct.HashMap.html#method.get_many_mut
+        /*
+        let s: &mut Box<dyn wasi_common::InputStream> = self
+            .table_mut()
+            .get_input_stream_mut(src)
+            .map_err(convert)?;
+        let d: &mut Box<dyn wasi_common::OutputStream> = self
+            .table_mut()
+            .get_output_stream_mut(dst)
+            .map_err(convert)?;
+
+        let bytes_spliced: u64 = s.splice(&mut **d, len).await.map_err(convert)?;
+
+        Ok(bytes_spliced)
+        */
+
+        todo!()
+    }
+
+    async fn forward(
+        &mut self,
+        _src: InputStream,
+        _dst: OutputStream,
+    ) -> HostResult<u64, StreamError> {
+        // TODO: We can't get two streams at the same time because they both
+        // carry the exclusive lifetime of `self`. When [`get_many_mut`] is
+        // stabilized, that could allow us to add a `get_many_stream_mut` or
+        // so which lets us do this.
+        //
+        // [`get_many_mut`]: https://doc.rust-lang.org/stable/std/collections/hash_map/struct.HashMap.html#method.get_many_mut
+        /*
+        let s: &mut Box<dyn wasi_common::InputStream> = self
+            .table_mut()
+            .get_input_stream_mut(src)
+            .map_err(convert)?;
+        let d: &mut Box<dyn wasi_common::OutputStream> = self
+            .table_mut()
+            .get_output_stream_mut(dst)
+            .map_err(convert)?;
+
+        let bytes_spliced: u64 = s.splice(&mut **d, len).await.map_err(convert)?;
+
+        Ok(bytes_spliced)
+        */
+
+        todo!()
+    }
+}

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -1,6 +1,7 @@
 mod clocks;
 mod exit;
 mod filesystem;
+mod io;
 mod logging;
 mod poll;
 mod random;
@@ -27,6 +28,7 @@ pub fn add_to_linker<T: Send>(
     wasi_logging::add_to_linker(l, f)?;
     wasi_stderr::add_to_linker(l, f)?;
     wasi_poll::add_to_linker(l, f)?;
+    wasi_io::add_to_linker(l, f)?;
     wasi_random::add_to_linker(l, f)?;
     wasi_tcp::add_to_linker(l, f)?;
     wasi_exit::add_to_linker(l, f)?;

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use cap_rand::RngCore;
 use cap_std::{ambient_authority, fs::Dir, time::Duration};
 use host::wasi_filesystem::Descriptor;
-use host::wasi_poll::WasiStream;
+use host::wasi_io::{InputStream, OutputStream};
 use host::{add_to_linker, WasiCommand, WasiCtx};
 use std::{
     io::{Cursor, Write},
@@ -50,8 +50,8 @@ async fn instantiate(path: &str) -> Result<(Store<WasiCtx>, WasiCommand)> {
 async fn run_hello_stdout(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     wasi.command(
         &mut store,
-        0 as WasiStream,
-        1 as WasiStream,
+        0 as InputStream,
+        1 as OutputStream,
         &["gussie", "sparky", "willa"],
         &[],
         &[],
@@ -64,8 +64,8 @@ async fn run_panic(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     let r = wasi
         .command(
             &mut store,
-            0 as WasiStream,
-            1 as WasiStream,
+            0 as InputStream,
+            1 as OutputStream,
             &[
                 "diesel",
                 "the",
@@ -88,8 +88,8 @@ async fn run_panic(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
 async fn run_args(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     wasi.command(
         &mut store,
-        0 as WasiStream,
-        1 as WasiStream,
+        0 as InputStream,
+        1 as OutputStream,
         &["hello", "this", "", "is an argument", "with 🚩 emoji"],
         &[],
         &[],
@@ -121,9 +121,16 @@ async fn run_random(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> 
 
     store.data_mut().random = Box::new(FakeRng);
 
-    wasi.command(&mut store, 0 as WasiStream, 1 as WasiStream, &[], &[], &[])
-        .await?
-        .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
+    wasi.command(
+        &mut store,
+        0 as InputStream,
+        1 as OutputStream,
+        &[],
+        &[],
+        &[],
+    )
+    .await?
+    .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_time(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -171,9 +178,16 @@ async fn run_time(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     store.data_mut().clocks.default_monotonic_clock =
         Box::new(FakeMonotonicClock { now: Mutex::new(0) });
 
-    wasi.command(&mut store, 0 as WasiStream, 1 as WasiStream, &[], &[], &[])
-        .await?
-        .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
+    wasi.command(
+        &mut store,
+        0 as InputStream,
+        1 as OutputStream,
+        &[],
+        &[],
+        &[],
+    )
+    .await?
+    .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_stdin(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -183,9 +197,16 @@ async fn run_stdin(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
             "So rested he by the Tumtum tree",
         ))));
 
-    wasi.command(&mut store, 0 as WasiStream, 1 as WasiStream, &[], &[], &[])
-        .await?
-        .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
+    wasi.command(
+        &mut store,
+        0 as InputStream,
+        1 as OutputStream,
+        &[],
+        &[],
+        &[],
+    )
+    .await?
+    .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -195,9 +216,16 @@ async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<
             "So rested he by the Tumtum tree",
         ))));
 
-    wasi.command(&mut store, 0 as WasiStream, 1 as WasiStream, &[], &[], &[])
-        .await?
-        .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
+    wasi.command(
+        &mut store,
+        0 as InputStream,
+        1 as OutputStream,
+        &[],
+        &[],
+        &[],
+    )
+    .await?
+    .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_env(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
@@ -415,8 +443,8 @@ async fn run_with_temp_dir(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Resu
 
     wasi.command(
         &mut store,
-        0 as WasiStream,
-        1 as WasiStream,
+        0 as InputStream,
+        1 as OutputStream,
         &["program", "/foo"],
         &[],
         &[(descriptor, "/foo")],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unused_variables)] // TODO: remove this when more things are implemented
 
 use crate::bindings::{
-    wasi_clocks, wasi_default_clocks, wasi_exit, wasi_filesystem, wasi_poll, wasi_random,
+    wasi_clocks, wasi_default_clocks, wasi_exit, wasi_filesystem, wasi_io, wasi_poll, wasi_random,
     wasi_stderr, wasi_tcp,
 };
 use core::arch::wasm32;
@@ -13,7 +13,7 @@ use core::mem::{self, align_of, forget, replace, size_of, ManuallyDrop, MaybeUni
 use core::ptr::{self, null_mut};
 use core::slice;
 use wasi::*;
-use wasi_poll::{Pollable, WasiStream};
+use wasi_poll::{InputStream, OutputStream, Pollable};
 
 #[macro_use]
 mod macros;
@@ -42,8 +42,8 @@ mod bindings {
 #[no_mangle]
 #[cfg(feature = "command")]
 pub unsafe extern "C" fn command(
-    stdin: WasiStream,
-    stdout: WasiStream,
+    stdin: InputStream,
+    stdout: OutputStream,
     args_ptr: *const WasmStr,
     args_len: usize,
     env_vars: StrTupleList,
@@ -753,10 +753,9 @@ pub unsafe extern "C" fn fd_read(
             Descriptor::Streams(streams) => {
                 let wasi_stream = streams.get_read_stream()?;
 
-                let read_len = unwrap_result(u32::try_from(len));
+                let read_len = unwrap_result(u64::try_from(len));
                 let wasi_stream = streams.get_read_stream()?;
-                let (data, end) =
-                    wasi_poll::read_stream(wasi_stream, read_len).map_err(|_| ERRNO_IO)?;
+                let (data, end) = wasi_io::read(wasi_stream, read_len).map_err(|_| ERRNO_IO)?;
 
                 assert_eq!(data.as_ptr(), ptr);
                 assert!(data.len() <= len);
@@ -1083,7 +1082,7 @@ pub unsafe extern "C" fn fd_write(
     State::with(|state| match state.get(fd)? {
         Descriptor::Streams(streams) => {
             let wasi_stream = streams.get_write_stream()?;
-            let bytes = wasi_poll::write_stream(wasi_stream, bytes).map_err(|_| ERRNO_IO)?;
+            let bytes = wasi_io::write(wasi_stream, bytes).map_err(|_| ERRNO_IO)?;
 
             // If this is a file, keep the current-position pointer up to date.
             if let StreamType::File(file) = &streams.type_ {
@@ -1951,10 +1950,10 @@ enum Descriptor {
 /// type-specific operations like seeking.
 struct Streams {
     /// The output stream, if present.
-    input: Cell<Option<WasiStream>>,
+    input: Cell<Option<InputStream>>,
 
     /// The input stream, if present.
-    output: Cell<Option<WasiStream>>,
+    output: Cell<Option<OutputStream>>,
 
     /// Information about the source of the stream.
     type_: StreamType,
@@ -1962,7 +1961,7 @@ struct Streams {
 
 impl Streams {
     /// Return the input stream, initializing it on the fly if needed.
-    fn get_read_stream(&self) -> Result<WasiStream, Errno> {
+    fn get_read_stream(&self) -> Result<InputStream, Errno> {
         match &self.input.get() {
             Some(wasi_stream) => Ok(*wasi_stream),
             None => match &self.type_ {
@@ -1979,7 +1978,7 @@ impl Streams {
     }
 
     /// Return the output stream, initializing it on the fly if needed.
-    fn get_write_stream(&self) -> Result<WasiStream, Errno> {
+    fn get_write_stream(&self) -> Result<OutputStream, Errno> {
         match &self.output.get() {
             Some(wasi_stream) => Ok(*wasi_stream),
             None => match &self.type_ {
@@ -2020,10 +2019,10 @@ impl Drop for Descriptor {
         match self {
             Descriptor::Streams(stream) => {
                 if let Some(input) = stream.input.get() {
-                    wasi_poll::drop_stream(input);
+                    wasi_io::drop_input_stream(input);
                 }
                 if let Some(output) = stream.output.get() {
-                    wasi_poll::drop_stream(output);
+                    wasi_io::drop_output_stream(output);
                 }
                 match &stream.type_ {
                     StreamType::File(file) => wasi_filesystem::close(file.fd),
@@ -2394,14 +2393,14 @@ impl State {
         self.get_stream_with_error(fd, ERRNO_SPIPE)
     }
 
-    fn get_read_stream(&self, fd: Fd) -> Result<WasiStream, Errno> {
+    fn get_read_stream(&self, fd: Fd) -> Result<InputStream, Errno> {
         match self.get(fd)? {
             Descriptor::Streams(streams) => streams.get_read_stream(),
             Descriptor::Closed(_) | Descriptor::Stderr => Err(ERRNO_BADF),
         }
     }
 
-    fn get_write_stream(&self, fd: Fd) -> Result<WasiStream, Errno> {
+    fn get_write_stream(&self, fd: Fd) -> Result<OutputStream, Errno> {
         match self.get(fd)? {
             Descriptor::Streams(streams) => streams.get_write_stream(),
             Descriptor::Closed(_) | Descriptor::Stderr => Err(ERRNO_BADF),

--- a/wasi-common/cap-std-sync/src/lib.rs
+++ b/wasi-common/cap-std-sync/src/lib.rs
@@ -47,7 +47,12 @@ pub use sched::sched_ctx;
 
 use crate::net::Listener;
 use cap_rand::{Rng, RngCore, SeedableRng};
-use wasi_common::{listener::WasiListener, stream::WasiStream, table::Table, WasiCtx};
+use wasi_common::{
+    listener::WasiListener,
+    stream::{InputStream, OutputStream},
+    table::Table,
+    WasiCtx,
+};
 
 pub struct WasiCtxBuilder(WasiCtx);
 
@@ -60,15 +65,15 @@ impl WasiCtxBuilder {
             Table::new(),
         ))
     }
-    pub fn stdin(mut self, f: Box<dyn WasiStream>) -> Self {
+    pub fn stdin(mut self, f: Box<dyn InputStream>) -> Self {
         self.0.set_stdin(f);
         self
     }
-    pub fn stdout(mut self, f: Box<dyn WasiStream>) -> Self {
+    pub fn stdout(mut self, f: Box<dyn OutputStream>) -> Self {
         self.0.set_stdout(f);
         self
     }
-    pub fn stderr(mut self, f: Box<dyn WasiStream>) -> Self {
+    pub fn stderr(mut self, f: Box<dyn OutputStream>) -> Self {
         self.0.set_stderr(f);
         self
     }

--- a/wasi-common/cap-std-sync/src/net.rs
+++ b/wasi-common/cap-std-sync/src/net.rs
@@ -363,7 +363,7 @@ macro_rules! wasi_stream_write_impl {
             }
 
             async fn readable(&self) -> Result<(), Error> {
-                if is_read_write(&self.0)?.0 {
+                if is_read_write(&*self.0)?.0 {
                     Ok(())
                 } else {
                     Err(Error::badf())

--- a/wasi-common/cap-std-sync/src/net.rs
+++ b/wasi-common/cap-std-sync/src/net.rs
@@ -1,4 +1,4 @@
-use io_extras::borrowed::BorrowedWriteable;
+use io_extras::borrowed::BorrowedReadable;
 #[cfg(windows)]
 use io_extras::os::windows::{AsHandleOrSocket, BorrowedHandleOrSocket};
 use io_lifetimes::AsSocketlike;
@@ -17,7 +17,7 @@ use system_interface::io::ReadReady;
 use wasi_common::{
     connection::{RiFlags, RoFlags, SdFlags, SiFlags, WasiConnection},
     listener::WasiListener,
-    stream::WasiStream,
+    stream::{InputStream, OutputStream},
     tcp_listener::WasiTcpListener,
     Error, ErrorExt,
 };
@@ -109,12 +109,24 @@ macro_rules! wasi_listener_impl {
             async fn accept(
                 &mut self,
                 nonblocking: bool,
-            ) -> Result<(Box<dyn WasiConnection>, Box<dyn WasiStream>), Error> {
+            ) -> Result<
+                (
+                    Box<dyn WasiConnection>,
+                    Box<dyn InputStream>,
+                    Box<dyn OutputStream>,
+                ),
+                Error,
+            > {
                 let (stream, _) = self.0.accept()?;
                 stream.set_nonblocking(nonblocking)?;
                 let connection = <$stream>::from_cap_std(stream);
-                let stream = connection.clone();
-                Ok((Box::new(connection), Box::new(stream)))
+                let input_stream = connection.clone();
+                let output_stream = connection.clone();
+                Ok((
+                    Box::new(connection),
+                    Box::new(input_stream),
+                    Box::new(output_stream),
+                ))
             }
 
             fn set_nonblocking(&mut self, flag: bool) -> Result<(), Error> {
@@ -159,12 +171,26 @@ macro_rules! wasi_tcp_listener_impl {
             async fn accept(
                 &mut self,
                 nonblocking: bool,
-            ) -> Result<(Box<dyn WasiConnection>, Box<dyn WasiStream>, SocketAddr), Error> {
+            ) -> Result<
+                (
+                    Box<dyn WasiConnection>,
+                    Box<dyn InputStream>,
+                    Box<dyn OutputStream>,
+                    SocketAddr,
+                ),
+                Error,
+            > {
                 let (stream, addr) = self.0.accept()?;
                 stream.set_nonblocking(nonblocking)?;
                 let connection = <$stream>::from_cap_std(stream);
-                let stream = connection.clone();
-                Ok((Box::new(connection), Box::new(stream), addr))
+                let input_stream = connection.clone();
+                let output_stream = connection.clone();
+                Ok((
+                    Box::new(connection),
+                    Box::new(input_stream),
+                    Box::new(output_stream),
+                    addr,
+                ))
             }
 
             fn set_nonblocking(&mut self, flag: bool) -> Result<(), Error> {
@@ -288,7 +314,7 @@ macro_rules! wasi_stream_write_impl {
         }
 
         #[async_trait::async_trait]
-        impl WasiStream for $ty {
+        impl InputStream for $ty {
             fn as_any(&self) -> &dyn Any {
                 self
             }
@@ -296,17 +322,9 @@ macro_rules! wasi_stream_write_impl {
             fn pollable_read(&self) -> Option<rustix::fd::BorrowedFd> {
                 Some(self.0.as_fd())
             }
-            #[cfg(unix)]
-            fn pollable_write(&self) -> Option<rustix::fd::BorrowedFd> {
-                Some(self.0.as_fd())
-            }
 
             #[cfg(windows)]
             fn pollable_read(&self) -> Option<io_extras::os::windows::BorrowedHandleOrSocket> {
-                Some(self.0.as_handle_or_socket())
-            }
-            #[cfg(windows)]
-            fn pollable_write(&self) -> Option<io_extras::os::windows::BorrowedHandleOrSocket> {
                 Some(self.0.as_handle_or_socket())
             }
 
@@ -333,6 +351,41 @@ macro_rules! wasi_stream_write_impl {
             fn is_read_vectored(&self) -> bool {
                 Read::is_read_vectored(&mut &*self.as_socketlike_view::<$std_ty>())
             }
+
+            async fn skip(&mut self, nelem: u64) -> Result<(u64, bool), Error> {
+                let num = io::copy(&mut io::Read::take(&*self.0, nelem), &mut io::sink())?;
+                Ok((num, num < nelem))
+            }
+
+            async fn num_ready_bytes(&self) -> Result<u64, Error> {
+                let val = self.as_socketlike_view::<$std_ty>().num_ready_bytes()?;
+                Ok(val)
+            }
+
+            async fn readable(&self) -> Result<(), Error> {
+                if is_read_write(&self.0)?.0 {
+                    Ok(())
+                } else {
+                    Err(Error::badf())
+                }
+            }
+        }
+        #[async_trait::async_trait]
+        impl OutputStream for $ty {
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+
+            #[cfg(unix)]
+            fn pollable_write(&self) -> Option<rustix::fd::BorrowedFd> {
+                Some(self.0.as_fd())
+            }
+
+            #[cfg(windows)]
+            fn pollable_write(&self) -> Option<io_extras::os::windows::BorrowedHandleOrSocket> {
+                Some(self.0.as_handle_or_socket())
+            }
+
             async fn write(&mut self, buf: &[u8]) -> Result<u64, Error> {
                 let n = Write::write(&mut &*self.as_socketlike_view::<$std_ty>(), buf)?;
                 Ok(n.try_into()?)
@@ -347,37 +400,22 @@ macro_rules! wasi_stream_write_impl {
             }
             async fn splice(
                 &mut self,
-                dst: &mut dyn WasiStream,
+                src: &mut dyn InputStream,
                 nelem: u64,
             ) -> Result<(u64, bool), Error> {
-                if let Some(writeable) = dst.pollable_write() {
+                if let Some(readable) = src.pollable_read() {
                     let num = io::copy(
-                        &mut io::Read::take(&*self.0, nelem),
-                        &mut BorrowedWriteable::borrow(writeable),
+                        &mut io::Read::take(BorrowedReadable::borrow(readable), nelem),
+                        &mut &*self.0,
                     )?;
                     Ok((num, num < nelem))
                 } else {
-                    WasiStream::splice(self, dst, nelem).await
+                    OutputStream::splice(self, src, nelem).await
                 }
-            }
-            async fn skip(&mut self, nelem: u64) -> Result<(u64, bool), Error> {
-                let num = io::copy(&mut io::Read::take(&*self.0, nelem), &mut io::sink())?;
-                Ok((num, num < nelem))
             }
             async fn write_repeated(&mut self, byte: u8, nelem: u64) -> Result<u64, Error> {
                 let num = io::copy(&mut io::Read::take(io::repeat(byte), nelem), &mut &*self.0)?;
                 Ok(num)
-            }
-            async fn num_ready_bytes(&self) -> Result<u64, Error> {
-                let val = self.as_socketlike_view::<$std_ty>().num_ready_bytes()?;
-                Ok(val)
-            }
-            async fn readable(&self) -> Result<(), Error> {
-                if is_read_write(&*self.0)?.0 {
-                    Ok(())
-                } else {
-                    Err(Error::badf())
-                }
             }
             async fn writable(&self) -> Result<(), Error> {
                 if is_read_write(&*self.0)?.1 {

--- a/wasi-common/cap-std-sync/src/sched.rs
+++ b/wasi-common/cap-std-sync/src/sched.rs
@@ -1,7 +1,7 @@
 use rustix::io::{PollFd, PollFlags};
 use std::thread;
 use std::time::Duration;
-use wasi_common::sched::subscription::{RwEventFlags, RwSubscriptionKind};
+use wasi_common::sched::subscription::{RwEventFlags, RwStream};
 use wasi_common::{
     sched::{Poll, WasiSched},
     Error, ErrorExt,
@@ -12,11 +12,11 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
     // separately below.
     let mut ready = false;
     let mut pollfds = Vec::new();
-    for (rwsub, kind) in poll.rw_subscriptions() {
-        match kind {
-            RwSubscriptionKind::Read => {
+    for rwsub in poll.rw_subscriptions() {
+        match rwsub.stream {
+            RwStream::Read(stream) => {
                 // Poll things that can be polled.
-                if let Some(fd) = rwsub.stream.pollable_read() {
+                if let Some(fd) = stream.pollable_read() {
                     #[cfg(unix)]
                     {
                         pollfds.push(PollFd::from_borrowed_fd(fd, PollFlags::IN));
@@ -34,7 +34,7 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
 
                 // Allow in-memory buffers or other immediately-available
                 // sources to complete successfully.
-                if let Ok(nbytes) = rwsub.stream.num_ready_bytes().await {
+                if let Ok(nbytes) = stream.num_ready_bytes().await {
                     if nbytes != 0 {
                         rwsub.complete(RwEventFlags::empty());
                         ready = true;
@@ -45,8 +45,8 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
                 return Err(Error::invalid_argument().context("stream is not pollable for reading"));
             }
 
-            RwSubscriptionKind::Write => {
-                let fd = rwsub.stream.pollable_write().ok_or(
+            RwStream::Write(stream) => {
+                let fd = stream.pollable_write().ok_or(
                     Error::invalid_argument().context("stream is not pollable for writing"),
                 )?;
 
@@ -97,22 +97,13 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
             }
         }
 
-        assert_eq!(
-            poll.rw_subscriptions()
-                .filter(|(sub, _kind)| !sub.is_complete())
-                .count(),
-            pollfds.len()
-        );
+        assert_eq!(poll.rw_subscriptions().count(), pollfds.len());
 
         // If the OS `poll` returned events, record them.
         if ready {
             // Iterate through the stream subscriptions, skipping those that
             // were already completed due to being immediately available.
-            for ((rwsub, _kind), pollfd) in poll
-                .rw_subscriptions()
-                .filter(|(sub, _kind)| !sub.is_complete())
-                .zip(pollfds.into_iter())
-            {
+            for (rwsub, pollfd) in poll.rw_subscriptions().zip(pollfds.into_iter()) {
                 let revents = pollfd.revents();
                 if revents.contains(PollFlags::NVAL) {
                     rwsub.error(Error::badf());

--- a/wasi-common/src/ctx.rs
+++ b/wasi-common/src/ctx.rs
@@ -3,7 +3,7 @@ use crate::dir::WasiDir;
 use crate::file::WasiFile;
 use crate::listener::WasiListener;
 use crate::sched::WasiSched;
-use crate::stream::WasiStream;
+use crate::stream::{InputStream, OutputStream};
 use crate::table::Table;
 use crate::Error;
 use cap_rand::RngCore;
@@ -38,7 +38,11 @@ impl WasiCtx {
         self.table_mut().insert_at(fd, Box::new(file));
     }
 
-    pub fn insert_stream(&mut self, fd: u32, stream: Box<dyn WasiStream>) {
+    pub fn insert_input_stream(&mut self, fd: u32, stream: Box<dyn InputStream>) {
+        self.table_mut().insert_at(fd, Box::new(stream));
+    }
+
+    pub fn insert_output_stream(&mut self, fd: u32, stream: Box<dyn OutputStream>) {
         self.table_mut().insert_at(fd, Box::new(stream));
     }
 
@@ -66,15 +70,15 @@ impl WasiCtx {
         &mut self.table
     }
 
-    pub fn set_stdin(&mut self, s: Box<dyn WasiStream>) {
-        self.insert_stream(0, s);
+    pub fn set_stdin(&mut self, s: Box<dyn InputStream>) {
+        self.insert_input_stream(0, s);
     }
 
-    pub fn set_stdout(&mut self, s: Box<dyn WasiStream>) {
-        self.insert_stream(1, s);
+    pub fn set_stdout(&mut self, s: Box<dyn OutputStream>) {
+        self.insert_output_stream(1, s);
     }
 
-    pub fn set_stderr(&mut self, s: Box<dyn WasiStream>) {
-        self.insert_stream(2, s);
+    pub fn set_stderr(&mut self, s: Box<dyn OutputStream>) {
+        self.insert_output_stream(2, s);
     }
 }

--- a/wasi-common/src/lib.rs
+++ b/wasi-common/src/lib.rs
@@ -75,6 +75,6 @@ pub use error::{Errno, Error, ErrorExt, I32Exit};
 pub use file::WasiFile;
 pub use listener::WasiListener;
 pub use sched::{Poll, WasiSched};
-pub use stream::WasiStream;
+pub use stream::{InputStream, OutputStream};
 pub use table::Table;
 pub use tcp_listener::WasiTcpListener;

--- a/wasi-common/src/listener.rs
+++ b/wasi-common/src/listener.rs
@@ -2,7 +2,7 @@
 
 use crate::connection::WasiConnection;
 use crate::Error;
-use crate::WasiStream;
+use crate::{InputStream, OutputStream};
 use std::any::Any;
 
 /// A socket listener.
@@ -13,7 +13,14 @@ pub trait WasiListener: Send + Sync {
     async fn accept(
         &mut self,
         nonblocking: bool,
-    ) -> Result<(Box<dyn WasiConnection>, Box<dyn WasiStream>), Error>;
+    ) -> Result<
+        (
+            Box<dyn WasiConnection>,
+            Box<dyn InputStream>,
+            Box<dyn OutputStream>,
+        ),
+        Error,
+    >;
 
     fn set_nonblocking(&mut self, flag: bool) -> Result<(), Error>;
 }

--- a/wasi-common/src/stream.rs
+++ b/wasi-common/src/stream.rs
@@ -1,13 +1,13 @@
 use crate::{Error, ErrorExt};
 use std::any::Any;
 
-/// A pseudo-stream.
+/// An input bytestream.
 ///
 /// This is "pseudo" because the real streams will be a type in wit, and
 /// built into the wit bindings, and will support async and type parameters.
 /// This pseudo-stream abstraction is synchronous and only supports bytes.
 #[async_trait::async_trait]
-pub trait WasiStream: Send + Sync {
+pub trait InputStream: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
     /// If this stream is reading from a host file descriptor, return it so
@@ -21,20 +21,6 @@ pub trait WasiStream: Send + Sync {
     /// that it can be polled with a host poll.
     #[cfg(windows)]
     fn pollable_read(&self) -> Option<io_extras::os::windows::BorrowedHandleOrSocket> {
-        None
-    }
-
-    /// If this stream is writing from a host file descriptor, return it so
-    /// that it can be polled with a host poll.
-    #[cfg(unix)]
-    fn pollable_write(&self) -> Option<rustix::fd::BorrowedFd> {
-        None
-    }
-
-    /// If this stream is writing from a host file descriptor, return it so
-    /// that it can be polled with a host poll.
-    #[cfg(windows)]
-    fn pollable_write(&self) -> Option<io_extras::os::windows::BorrowedHandleOrSocket> {
         None
     }
 
@@ -58,42 +44,6 @@ pub trait WasiStream: Send + Sync {
         false
     }
 
-    /// Write bytes. On success, returns the number of bytes written.
-    async fn write(&mut self, _buf: &[u8]) -> Result<u64, Error> {
-        Err(Error::badf())
-    }
-
-    /// Vectored-I/O form of `write`.
-    async fn write_vectored<'a>(&mut self, _bufs: &[std::io::IoSlice<'a>]) -> Result<u64, Error> {
-        Err(Error::badf())
-    }
-
-    /// Test whether vectored I/O writes are known to be optimized in the
-    /// underlying implementation.
-    fn is_write_vectored(&self) -> bool {
-        false
-    }
-
-    /// Transfer bytes directly from an input stream to an output stream.
-    async fn splice(&mut self, dst: &mut dyn WasiStream, nelem: u64) -> Result<(u64, bool), Error> {
-        let mut nspliced = 0;
-        let mut saw_end = false;
-
-        // TODO: Optimize by splicing more than one byte at a time.
-        for _ in 0..nelem {
-            let mut buf = [0u8];
-            let (num, end) = self.read(&mut buf).await?;
-            dst.write(&buf).await?;
-            nspliced += num;
-            if end {
-                saw_end = true;
-                break;
-            }
-        }
-
-        Ok((nspliced, saw_end))
-    }
-
     /// Read bytes from a stream and discard them.
     async fn skip(&mut self, nelem: u64) -> Result<(u64, bool), Error> {
         let mut nread = 0;
@@ -112,6 +62,78 @@ pub trait WasiStream: Send + Sync {
         Ok((nread, saw_end))
     }
 
+    /// Return the number of bytes that may be read without blocking.
+    async fn num_ready_bytes(&self) -> Result<u64, Error> {
+        Ok(0)
+    }
+
+    /// Test whether this stream is readable.
+    async fn readable(&self) -> Result<(), Error>;
+}
+
+/// An output bytestream.
+///
+/// This is "pseudo" because the real streams will be a type in wit, and
+/// built into the wit bindings, and will support async and type parameters.
+/// This pseudo-stream abstraction is synchronous and only supports bytes.
+#[async_trait::async_trait]
+pub trait OutputStream: Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+
+    /// If this stream is writing from a host file descriptor, return it so
+    /// that it can be polled with a host poll.
+    #[cfg(unix)]
+    fn pollable_write(&self) -> Option<rustix::fd::BorrowedFd> {
+        None
+    }
+
+    /// If this stream is writing from a host file descriptor, return it so
+    /// that it can be polled with a host poll.
+    #[cfg(windows)]
+    fn pollable_write(&self) -> Option<io_extras::os::windows::BorrowedHandleOrSocket> {
+        None
+    }
+
+    /// Write bytes. On success, returns the number of bytes written.
+    async fn write(&mut self, _buf: &[u8]) -> Result<u64, Error> {
+        Err(Error::badf())
+    }
+
+    /// Vectored-I/O form of `write`.
+    async fn write_vectored<'a>(&mut self, _bufs: &[std::io::IoSlice<'a>]) -> Result<u64, Error> {
+        Err(Error::badf())
+    }
+
+    /// Test whether vectored I/O writes are known to be optimized in the
+    /// underlying implementation.
+    fn is_write_vectored(&self) -> bool {
+        false
+    }
+
+    /// Transfer bytes directly from an input stream to an output stream.
+    async fn splice(
+        &mut self,
+        src: &mut dyn InputStream,
+        nelem: u64,
+    ) -> Result<(u64, bool), Error> {
+        let mut nspliced = 0;
+        let mut saw_end = false;
+
+        // TODO: Optimize by splicing more than one byte at a time.
+        for _ in 0..nelem {
+            let mut buf = [0u8];
+            let (num, end) = src.read(&mut buf).await?;
+            self.write(&buf).await?;
+            nspliced += num;
+            if end {
+                saw_end = true;
+                break;
+            }
+        }
+
+        Ok((nspliced, saw_end))
+    }
+
     /// Repeatedly write a byte to a stream.
     async fn write_repeated(&mut self, byte: u8, nelem: u64) -> Result<u64, Error> {
         let mut nwritten = 0;
@@ -128,27 +150,29 @@ pub trait WasiStream: Send + Sync {
         Ok(nwritten)
     }
 
-    /// Return the number of bytes that may be read without blocking.
-    async fn num_ready_bytes(&self) -> Result<u64, Error> {
-        Ok(0)
-    }
-
-    /// Test whether this stream is readable.
-    async fn readable(&self) -> Result<(), Error>;
-
     /// Test whether this stream is writeable.
     async fn writable(&self) -> Result<(), Error>;
 }
 
 pub trait TableStreamExt {
-    fn get_stream(&self, fd: u32) -> Result<&dyn WasiStream, Error>;
-    fn get_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn WasiStream>, Error>;
+    fn get_input_stream(&self, fd: u32) -> Result<&dyn InputStream, Error>;
+    fn get_input_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn InputStream>, Error>;
+
+    fn get_output_stream(&self, fd: u32) -> Result<&dyn OutputStream, Error>;
+    fn get_output_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn OutputStream>, Error>;
 }
 impl TableStreamExt for crate::table::Table {
-    fn get_stream(&self, fd: u32) -> Result<&dyn WasiStream, Error> {
-        self.get::<Box<dyn WasiStream>>(fd).map(|f| f.as_ref())
+    fn get_input_stream(&self, fd: u32) -> Result<&dyn InputStream, Error> {
+        self.get::<Box<dyn InputStream>>(fd).map(|f| f.as_ref())
     }
-    fn get_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn WasiStream>, Error> {
-        self.get_mut::<Box<dyn WasiStream>>(fd)
+    fn get_input_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn InputStream>, Error> {
+        self.get_mut::<Box<dyn InputStream>>(fd)
+    }
+
+    fn get_output_stream(&self, fd: u32) -> Result<&dyn OutputStream, Error> {
+        self.get::<Box<dyn OutputStream>>(fd).map(|f| f.as_ref())
+    }
+    fn get_output_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn OutputStream>, Error> {
+        self.get_mut::<Box<dyn OutputStream>>(fd)
     }
 }

--- a/wasi-common/src/tcp_listener.rs
+++ b/wasi-common/src/tcp_listener.rs
@@ -3,7 +3,7 @@
 use crate::connection::WasiConnection;
 use crate::Error;
 use crate::WasiListener;
-use crate::WasiStream;
+use crate::{InputStream, OutputStream};
 use std::any::Any;
 use std::net::SocketAddr;
 
@@ -15,7 +15,15 @@ pub trait WasiTcpListener: Send + Sync {
     async fn accept(
         &mut self,
         nonblocking: bool,
-    ) -> Result<(Box<dyn WasiConnection>, Box<dyn WasiStream>, SocketAddr), Error>;
+    ) -> Result<
+        (
+            Box<dyn WasiConnection>,
+            Box<dyn InputStream>,
+            Box<dyn OutputStream>,
+            SocketAddr,
+        ),
+        Error,
+    >;
 
     fn set_nonblocking(&mut self, flag: bool) -> Result<(), Error>;
 

--- a/wit/wasi-command.wit
+++ b/wit/wasi-command.wit
@@ -6,14 +6,15 @@ default world wasi-command {
   import wasi-filesystem: pkg.wasi-filesystem
   import wasi-random: pkg.wasi-random
   import wasi-poll: pkg.wasi-poll
+  import wasi-io: pkg.wasi-io
   import wasi-tcp: pkg.wasi-tcp
   import wasi-ip: pkg.wasi-ip
   import wasi-dns: pkg.wasi-dns
   import wasi-exit: pkg.wasi-exit
 
   export command: func(
-    stdin: u32, // TODO `use` from `wasi-poll`
-    stdout: u32, // TODO: `use` from `wasi-poll`
+    stdin: u32, // TODO `use` from `wasi-io`
+    stdout: u32, // TODO: `use` from `wasi-io`
     args: list<string>,
     env-vars: list<tuple<string, string>>,
     preopens: list<tuple<u32, string>> // TODO: `use` from `wasi-filesystem`

--- a/wit/wasi-filesystem.wit
+++ b/wit/wasi-filesystem.wit
@@ -14,7 +14,7 @@
 /// Some of the content and ideas here are derived from
 /// [CloudABI](https://github.com/NuxiNL/cloudabi).
 default interface wasi-filesystem {
-  use pkg.wasi-poll.{wasi-stream}
+  use pkg.wasi-io.{input-stream, output-stream}
   use pkg.wasi-clocks.{datetime}
 
   /// A "file" descriptor. In the future, this will be replaced by handle types.
@@ -361,7 +361,7 @@ default interface wasi-filesystem {
       fd: descriptor,
       /// The offset within the file at which to start reading.
       offset: filesize,
-  ) -> result<wasi-stream, errno>
+  ) -> result<input-stream, errno>
 
   /// Return a stream for writing to a file.
   ///
@@ -371,7 +371,7 @@ default interface wasi-filesystem {
       fd: descriptor,
       /// The offset within the file at which to start writing.
       offset: filesize,
-  ) -> result<wasi-stream, errno>
+  ) -> result<output-stream, errno>
 
   /// Return a stream for appending to a file.
   ///
@@ -380,7 +380,7 @@ default interface wasi-filesystem {
   append-via-stream: func(
       /// The resource to operate on.
       fd: descriptor,
-  ) -> result<wasi-stream, errno>
+  ) -> result<output-stream, errno>
 
   /// Read from a file at a given offset.
   ///

--- a/wit/wasi-io.wit
+++ b/wit/wasi-io.wit
@@ -1,0 +1,128 @@
+default interface wasi-io {
+    /// An error type returned from a stream operation. Currently this
+    /// doesn't provide any additional information.
+    record stream-error {}
+    
+    /// An input bytestream. In the future, this will be replaced by handle
+    /// types.
+    /// 
+    /// This conceptually represents a `stream<u8, _>`. It's temporary 
+    /// scaffolding until component-model's async features are ready. 
+    /// 
+    /// And at present, it is a `u32` instead of being an actual handle, until 
+    /// the wit-bindgen implementation of handles and resources is ready. 
+    type input-stream = u32
+    
+    /// Read bytes from a stream.
+    ///
+    /// This function returns a list of bytes containing the data that was
+    /// read, along with a bool indicating whether the end of the stream
+    /// was reached. The returned list will contain up to `len` bytes; it
+    /// may return fewer than requested, but not more.
+    ///
+    /// Once a stream has reached the end, subsequent calls to read or
+    /// `skip` will always report end-of-stream rather than producing more
+    /// data.
+    ///
+    /// If `len` is 0, it represents a request to read 0 bytes, which should
+    /// always succeed, assuming the stream hasn't reached its end yet, and
+    /// return an empty list.
+    ///
+    /// The len here is a `u64`, but some callees may not be able to allocate
+    /// a buffer as large as that would imply.
+    /// FIXME: describe what happens if allocation fails.
+    read: func(
+        /// The stream to read from
+        src: input-stream,
+        /// The maximum number of bytes to read
+        len: u64
+    ) -> result<tuple<list<u8>, bool>, stream-error>
+    
+    /// Skip bytes from a stream.
+    ///
+    /// This is similar to the `read` function, but avoids copying the
+    /// bytes into the instance.
+    ///
+    /// Once a stream has reached the end, subsequent calls to read or
+    /// `skip` will always report end-of-stream rather than producing more
+    /// data.
+    ///
+    /// This function returns the number of bytes skipped, along with a bool
+    /// indicating whether the end of the stream was reached. The returned
+    /// value will be at most `len`; it may be less.
+    skip: func(
+        /// The stream to skip in
+        src: input-stream,
+        /// The maximum number of bytes to skip.
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+    
+    /// An output bytestream. In the future, this will be replaced by handle
+    /// types.
+    /// 
+    /// This conceptually represents a `stream<u8, _>`. It's temporary 
+    /// scaffolding until component-model's async features are ready. 
+    /// 
+    /// And at present, it is a `u32` instead of being an actual handle, until 
+    /// the wit-bindgen implementation of handles and resources is ready. 
+    type output-stream = u32
+    
+    /// Write bytes to a stream.
+    ///
+    /// This function returns a `u64` indicating the number of bytes from
+    /// `buf` that were written; it may be less than the full list.
+    write: func(
+        /// The stream to write to
+        dst: output-stream,
+        /// Data to write
+        buf: list<u8>
+    ) -> result<u64, stream-error>
+    
+    /// Write a single byte multiple times to a stream.
+    ///
+    /// This function returns a `u64` indicating the number of copies of
+    /// `byte` that were written; it may be less than `len`.
+    write-repeated: func(
+        /// The stream to write to
+        dst: output-stream,
+        /// The byte to write
+        byte: u8,
+        /// The number of times to write it
+        len: u64
+    ) -> result<u64, stream-error>
+    
+    /// Read from one stream and write to another.
+    ///
+    /// This function returns the number of bytes transferred; it may be less
+    /// than `len`.
+    splice: func(
+        /// The stream to write to
+        dst: output-stream,
+        /// The stream to read from
+        src: input-stream,
+        /// The number of bytes to splice
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+    
+    /// Forward the entire contents of an input stream to an output stream.
+    ///
+    /// This function repeatedly reads from the input stream and writes
+    /// the data to the output stream, until the end of the input stream
+    /// is reached, or an error is encountered.
+    ///
+    /// This function returns the number of bytes transferred.
+    forward: func(
+        /// The stream to write to
+        dst: output-stream,
+        /// The stream to read from
+        src: input-stream
+    ) -> result<u64, stream-error>
+
+    /// Dispose of the specified input-stream, after which it may no longer
+    /// be used.
+    drop-input-stream: func(f: input-stream)
+
+    /// Dispose of the specified output-stream, after which it may no longer
+    /// be used.
+    drop-output-stream: func(f: output-stream)
+}

--- a/wit/wasi-poll.wit
+++ b/wit/wasi-poll.wit
@@ -4,6 +4,7 @@
 /// multiple handles at once.
 default interface wasi-poll {
   use pkg.wasi-clocks.{wall-clock, monotonic-clock, datetime, instant}
+  use pkg.wasi-io.{input-stream, output-stream}
 
   /// A "pollable" handle.
   ///
@@ -19,79 +20,16 @@ default interface wasi-poll {
   /// that they do not outlive the resource they reference.
   type pollable = u32
 
-  /// A "bytestream" handle.
-  ///
-  /// This conceptually represents a `stream<u8, _>`. It's temporary
-  /// scaffolding until component-model's async features are ready.
-  ///
-  /// And at present, it is a `u32` instead of being an actual handle, until
-  /// the wit-bindgen implementation of handles and resources is ready.
-  type wasi-stream = u32
-
   /// Dispose of the specified `pollable`, after which it may no longer be used.
   drop-pollable: func(f: pollable)
 
-  /// Dispose of the specified stream, after which it may no longer be used.
-  drop-stream: func(f: wasi-stream)
-
-  /// Size of a range of bytes in memory.
-  type size = u32
-
-  /// FIXME: This should just be `_` in the `result`'s below, but in the
-  /// bindings, `()` doesn't impl `std::error::Error`.
-  record stream-error {}
-
-  /// Read bytes from a stream.
-  read-stream: func(
-      /// The stream to operate on.
-      %stream: wasi-stream,
-      /// The maximum number of bytes to read.
-      len: size,
-  ) -> result<tuple<list<u8>, bool>, stream-error>
-
-  /// Write bytes to a stream.
-  write-stream: func(
-      /// The stream to operate on.
-      %stream: wasi-stream,
-      /// Data to write
-      buf: list<u8>,
-  ) -> result<size, stream-error>
-
-  /// Skip bytes from a stream.
-  skip-stream: func(
-      /// The stream to operate on.
-      %stream: wasi-stream,
-      /// The maximum number of bytes to skip.
-      len: u64,
-  ) -> result<tuple<u64, bool>, stream-error>
-
-  /// Write a byte multiple times to a stream.
-  write-repeated-stream: func(
-      /// The stream to operate on.
-      %stream: wasi-stream,
-      /// The byte to write
-      byte: u8,
-      /// The number of times to write it.
-      len: u64,
-  ) -> result<u64, stream-error>
-
-  /// Read from one stream and write to another.
-  splice-stream: func(
-      /// The stream to read from.
-      src: wasi-stream,
-      /// The stream to write to.
-      dst: wasi-stream,
-      /// The number of bytes to splice.
-      len: u64,
-  ) -> result<tuple<u64, bool>, stream-error>
-
   /// Create a `pollable` which will resolve once either the specified stream has bytes
   /// available to read or the other end of the stream has been closed.
-  subscribe-read: func(s: wasi-stream) -> pollable
+  subscribe-read: func(s: input-stream) -> pollable
 
   /// Create a `pollable` which will resolve once either the specified stream is ready
   /// to accept bytes or the other end of the stream has been closed.
-  subscribe-write: func(s: wasi-stream) -> pollable
+  subscribe-write: func(s: output-stream) -> pollable
 
   /// Create a `pollable` which will resolve once the specified time has been reached.
   subscribe-monotonic-clock: func(clock: monotonic-clock, when: instant, absolute: bool) -> pollable

--- a/wit/wasi-tcp.wit
+++ b/wit/wasi-tcp.wit
@@ -7,7 +7,8 @@
 ///
 /// Non-blocking connections should be supported by calling connect() with the nonblock flag. Then you poll on the resulting connection for output. Once poll returns, you can call `is-connected` to determine the connection status and receive(connection, 1) to collect the error status. This follows the existing usage under POSIX.
 default interface wasi-tcp {
-  use pkg.wasi-poll.{pollable, wasi-stream}
+  use pkg.wasi-poll.{pollable}
+  use pkg.wasi-io.{input-stream, output-stream}
   use pkg.wasi-net.{network}
 
   // TODO: Use ip-socket-address from wasi-ip.
@@ -165,11 +166,14 @@ default interface wasi-tcp {
   /// indication to poll for incoming data on the listener. Otherwise, this
   /// function will block until an incoming connection is available.
   ///
+  /// Returns a tuple of a connection handle, and input stream, and an output
+  /// stream for the socket.
+  ///
   /// The connection should be destroyed with `close-connection` when no longer in use.
   accept: func(
       listener: listener,
       %flags: connection-flags
-  ) -> result<tuple<connection, wasi-stream>, errno>
+  ) -> result<tuple<connection, input-stream, output-stream>, errno>
 
   /// Accepts a new incoming connection on a TCP socket.
   ///
@@ -178,7 +182,7 @@ default interface wasi-tcp {
   accept-tcp: func(
       listener: tcp-listener,
       %flags: connection-flags
-  ) -> result<tuple<connection, wasi-stream, ip-socket-address>, errno>
+  ) -> result<tuple<connection, input-stream, output-stream, ip-socket-address>, errno>
 
   /// Connect to a remote endpoint.
   ///
@@ -200,7 +204,7 @@ default interface wasi-tcp {
       local-address: ip-socket-address,
       remote-address: ip-socket-address,
       %flags: connection-flags,
-  ) -> result<tuple<connection, wasi-stream>, errno>
+  ) -> result<tuple<connection, input-stream, output-stream>, errno>
 
   /// Send bytes to the remote connection.
   ///

--- a/wit/wasi.wit
+++ b/wit/wasi.wit
@@ -6,6 +6,7 @@ default world wasi {
   import wasi-filesystem: pkg.wasi-filesystem
   import wasi-random: pkg.wasi-random
   import wasi-poll: pkg.wasi-poll
+  import wasi-io: pkg.wasi-io
   import wasi-tcp: pkg.wasi-tcp
   import wasi-ip: pkg.wasi-ip
   import wasi-dns: pkg.wasi-dns


### PR DESCRIPTION
This syncs the prototype's streams with the upstream wasi-io repo.

Streams are unidirectional, so this allows us to statically describe whether something is an input stream or an output stream in an interface.

This differs a little from the component model async streams, which don't have separate input and output streams, but it does partially reflect how the component model async design differentiates between input streams in type signatures, which are passed in as arguments, and output streams, which are returned as return values.