### PR TITLE
Fix `poll_oneoff`'s timeout value when no timeout is requested.

### DIFF
--- a/wasi-common/cap-std-sync/src/sched.rs
+++ b/wasi-common/cap-std-sync/src/sched.rs
@@ -80,7 +80,8 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
                     .try_into()
                     .map_err(|_| Error::overflow().context("poll timeout"))?
             } else {
-                std::os::raw::c_int::max_value()
+                // A negative value requests an infinite timeout.
+                -1
             };
             tracing::debug!(
                 poll_timeout = tracing::field::debug(poll_timeout),


### PR DESCRIPTION
When no timeout is requested, pass `-1` to the host `poll` to disable the timeout.