### PR TITLE
short-circuit reentrance when allocating stack and `State`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
         path: wasi_snapshot_preview1.command.wasm
     - run: cargo build --target wasm32-unknown-unknown --release
 
-    - run: cargo install --git https://github.com/bytecodealliance/wit-bindgen --rev 67c7d748cf561ee32e7f52e2d796501e875e4c50 wit-bindgen-cli
+    - run: cargo install --locked --git https://github.com/bytecodealliance/wit-bindgen --rev ef00821dc41fb5fd212311757713c61e8bffa3ba wit-bindgen-cli
     - run: wit-bindgen c ./wit --world wasi-command
     - uses: actions/upload-artifact@v3
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ checksum = "ec8ad6edb4840b78c5c3d88de606b22252d552b55f3a4699fbb10fc070ec3049"
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arrayvec"
@@ -51,9 +51,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -68,9 +68,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bincode"
@@ -138,7 +138,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "windows-sys 0.45.0",
- "winx 0.35.0",
+ "winx",
 ]
 
 [[package]]
@@ -166,21 +166,21 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbc0de1c393e0d10e78c37f06a991951eb55d6e8758b225f256f3562a242101"
+checksum = "472931750f90fbf0731c886c2937521e25772942577a182e7ace5bc561d10e3b"
 dependencies = [
  "cap-primitives",
  "once_cell",
  "rustix",
- "winx 0.34.0",
+ "winx",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
@@ -211,16 +211,16 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.93.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "0.94.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.93.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "0.94.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "arrayvec",
  "bumpalo",
@@ -239,29 +239,29 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.93.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "0.94.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.93.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "0.94.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.93.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "0.94.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.93.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "0.94.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -271,13 +271,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.93.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "0.94.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 
 [[package]]
 name = "cranelift-native"
-version = "0.93.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "0.94.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -286,8 +286,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.93.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "0.94.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -295,7 +295,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.97.0",
+ "wasmparser 0.100.0",
  "wasmtime-types",
 ]
 
@@ -394,15 +394,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -564,6 +564,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "host"
@@ -657,14 +663,14 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -807,7 +813,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -861,9 +867,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -971,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
+checksum = "abdf64625ea14dd2a89d8076aaa4059a8380163dce34b978ddda25c403afe241"
 dependencies = [
  "fxhash",
  "log",
@@ -1126,14 +1132,14 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys 0.45.0",
- "winx 0.35.0",
+ "winx",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
@@ -1194,7 +1200,7 @@ name = "test-programs-macros"
 version = "0.0.0"
 dependencies = [
  "quote",
- "wit-component 0.5.1 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
+ "wit-component",
 ]
 
 [[package]]
@@ -1219,10 +1225,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
@@ -1237,15 +1244,15 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "pin-project-lite",
@@ -1359,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -1464,59 +1471,30 @@ dependencies = [
  "byte-array",
  "object",
  "wasi",
- "wasm-encoder 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-encoder",
  "wit-bindgen-guest-rust",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ab2fe77b325731603297debb4573e002d06ae0aa1f4dc108585c81961e0609"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a584273ccc2d9311f1dd19dc3fb26054661fa3e373d53ede5d1144ba07a9acd"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.22.1"
-source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
+checksum = "1c3e4bc09095436c8e7584d86d33e6c3ee67045af8fb262cbb9cc321de553428"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b2a2b173b386ac9f3be7dfedc24e1aa0735e89719b0576d14ac6fc796af765"
+checksum = "139cad89459dd2ae22ec2ebd439db058f3b0cab7bef98e9856ff7c446ec60b2a"
 dependencies = [
  "anyhow",
  "indexmap",
  "serde",
- "wasm-encoder 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.1.1"
-source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
-dependencies = [
- "anyhow",
- "indexmap",
- "serde",
- "wasm-encoder 0.22.1 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
- "wasmparser 0.99.0 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
+ "wasm-encoder",
+ "wasmparser 0.100.0",
 ]
 
 [[package]]
@@ -1530,28 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.97.0"
+version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98123a0d2bacf9286239231b116cbd66c65d9b89793f7c9bba3a3ae7f1b15f3"
-dependencies = [
- "indexmap",
- "url",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.99.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef3b717afc67f848f412d4f02c127dd3e35a0eecd58c684580414df4fde01d3"
-dependencies = [
- "indexmap",
- "url",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.99.0"
-source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
+checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
 dependencies = [
  "indexmap",
  "url",
@@ -1559,18 +1518,18 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.49"
+version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c13dff901f9354fa9a6a877152d9c5642513645985635c9b83bcca99e40ea1"
+checksum = "b2d3f7d7cb1e00ae9f91bb21f2856cdc68a913afb3b6b33fca5a83dba8c8c4eb"
 dependencies = [
  "anyhow",
- "wasmparser 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.100.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1587,7 +1546,7 @@ dependencies = [
  "rayon",
  "serde",
  "target-lexicon",
- "wasmparser 0.97.0",
+ "wasmparser 0.100.0",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -1597,21 +1556,21 @@ dependencies = [
  "wasmtime-jit",
  "wasmtime-runtime",
  "wat",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1623,14 +1582,14 @@ dependencies = [
  "serde",
  "sha2",
  "toml",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
  "zstd",
 ]
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1638,18 +1597,18 @@ dependencies = [
  "syn",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.4.1",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1662,14 +1621,14 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.97.0",
+ "wasmparser 0.100.0",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -1680,8 +1639,8 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasm-encoder 0.21.0",
- "wasmparser 0.97.0",
+ "wasm-encoder",
+ "wasmparser 0.100.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -1689,20 +1648,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "cc",
  "cfg-if",
  "rustix",
  "wasmtime-asm-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-jit"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1720,13 +1679,13 @@ dependencies = [
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "object",
  "once_cell",
@@ -1735,18 +1694,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1765,47 +1724,47 @@ dependencies = [
  "wasmtime-environ",
  "wasmtime-fiber",
  "wasmtime-jit-debug",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.97.0",
+ "wasmparser 0.100.0",
 ]
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "6.0.0"
-source = "git+https://github.com/bytecodealliance/wasmtime#b58a197d33f044193c3d608010f5e6ec394ac07e"
+version = "7.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime#6cddc923f3e8f417acfc4e8653508e376af369e0"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.4.1",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wast"
-version = "52.0.2"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707a9fd59b0144c530f0a31f21737036ffea6ece492918cae0843dd09b6f9bc9"
+checksum = "8244fa24196b1d8fd3ca4a96a3a164c40f846498c5deab6caf414c67340ca4af"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d73cbaa81acc2f8a3303e2289205c971d99c89245c2f56ab8765c4daabc2be"
+checksum = "4620f1059add6dad511decb9d5d88b4a0a0d3e2e315ed34f79b0dc0dce18aa4b"
 dependencies = [
  "wast",
 ]
@@ -1924,17 +1883,6 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winx"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9baf690e238840de84bbfad6ad72d6628c41d34c1a5e276dab7fb2c9167ca1ac"
-dependencies = [
- "bitflags",
- "io-lifetimes",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "winx"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "129cd8ee937d535e1a239d9d3c9c0525af0454bc0967d9211a251be062513520"
@@ -1947,28 +1895,28 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-core"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#67c7d748cf561ee32e7f52e2d796501e875e4c50"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#ef00821dc41fb5fd212311757713c61e8bffa3ba"
 dependencies = [
  "anyhow",
- "wit-component 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wit-parser 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-component",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-bindgen-gen-guest-rust"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#67c7d748cf561ee32e7f52e2d796501e875e4c50"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#ef00821dc41fb5fd212311757713c61e8bffa3ba"
 dependencies = [
  "heck",
  "wit-bindgen-core",
  "wit-bindgen-gen-rust-lib",
- "wit-component 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-gen-rust-lib"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#67c7d748cf561ee32e7f52e2d796501e875e4c50"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#ef00821dc41fb5fd212311757713c61e8bffa3ba"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -1977,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-guest-rust"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#67c7d748cf561ee32e7f52e2d796501e875e4c50"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#ef00821dc41fb5fd212311757713c61e8bffa3ba"
 dependencies = [
  "bitflags",
  "wit-bindgen-guest-rust-macro",
@@ -1986,83 +1934,38 @@ dependencies = [
 [[package]]
 name = "wit-bindgen-guest-rust-macro"
 version = "0.3.0"
-source = "git+https://github.com/bytecodealliance/wit-bindgen#67c7d748cf561ee32e7f52e2d796501e875e4c50"
+source = "git+https://github.com/bytecodealliance/wit-bindgen#ef00821dc41fb5fd212311757713c61e8bffa3ba"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "syn",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-rust",
- "wit-component 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-component"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb56cd67422410bcd960039f50fdd97cea44af24e8ff42a51f0e944645f6f2f"
+checksum = "0404e6b5c75131ae4bc05de7a14917a62030f67625804f4530ab39368321d857"
 dependencies = [
  "anyhow",
  "bitflags",
  "indexmap",
  "log",
  "url",
- "wasm-encoder 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-metadata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wit-parser 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.5.1"
-source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "url",
- "wasm-encoder 0.22.1 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
- "wasm-metadata 0.1.1 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
- "wasmparser 0.99.0 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
- "wit-parser 0.5.0 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.100.0",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e60c4242d4cf4394fac7587c0d96c39b3c0fb09e638815c3f244f6bb5356f04"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "pulldown-cmark",
- "unicode-xid",
- "url",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "896b2d88f139eb303e8e76fd72925115b11aad1944887ec2e5b2eeac1e58526f"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "pulldown-cmark",
- "unicode-xid",
- "url",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.5.0"
-source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
+checksum = "6e0fe225a32528b42a7037add1b5ed1dff83288f21a067007b34565ce87fc2c7"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -2094,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.5+zstd.1.5.2"
+version = "2.0.7+zstd.1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc50ffce891ad571e9f9afe5039c4837bede781ac4bb13052ed7ae695518596"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ name = "test-programs-macros"
 version = "0.0.0"
 dependencies = [
  "quote",
- "wit-component",
+ "wit-component 0.5.1 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
 ]
 
 [[package]]
@@ -1464,7 +1464,7 @@ dependencies = [
  "byte-array",
  "object",
  "wasi",
- "wasm-encoder 0.22.1",
+ "wasm-encoder 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wit-bindgen-guest-rust",
 ]
 
@@ -1487,6 +1487,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.22.1"
+source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,8 +1503,20 @@ dependencies = [
  "anyhow",
  "indexmap",
  "serde",
- "wasm-encoder 0.22.1",
- "wasmparser 0.99.0",
+ "wasm-encoder 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.1.1"
+source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "serde",
+ "wasm-encoder 0.22.1 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
+ "wasmparser 0.99.0 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
 ]
 
 [[package]]
@@ -1529,13 +1549,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.99.0"
+source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
+dependencies = [
+ "indexmap",
+ "url",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c13dff901f9354fa9a6a877152d9c5642513645985635c9b83bcca99e40ea1"
 dependencies = [
  "anyhow",
- "wasmparser 0.99.0",
+ "wasmparser 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1769,7 +1798,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.22.1",
+ "wasm-encoder 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1921,8 +1950,8 @@ version = "0.3.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen#67c7d748cf561ee32e7f52e2d796501e875e4c50"
 dependencies = [
  "anyhow",
- "wit-component",
- "wit-parser 0.5.0",
+ "wit-component 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-parser 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1933,7 +1962,7 @@ dependencies = [
  "heck",
  "wit-bindgen-core",
  "wit-bindgen-gen-rust-lib",
- "wit-component",
+ "wit-component 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1964,7 +1993,7 @@ dependencies = [
  "syn",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-rust",
- "wit-component",
+ "wit-component 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1978,10 +2007,26 @@ dependencies = [
  "indexmap",
  "log",
  "url",
- "wasm-encoder 0.22.1",
- "wasm-metadata",
- "wasmparser 0.99.0",
- "wit-parser 0.5.0",
+ "wasm-encoder 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-metadata 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-parser 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.5.1"
+source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "url",
+ "wasm-encoder 0.22.1 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
+ "wasm-metadata 0.1.1 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
+ "wasmparser 0.99.0 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
+ "wit-parser 0.5.0 (git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport)",
 ]
 
 [[package]]
@@ -2004,6 +2049,20 @@ name = "wit-parser"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "896b2d88f139eb303e8e76fd72925115b11aad1944887ec2e5b2eeac1e58526f"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "pulldown-cmark",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.5.0"
+source = "git+https://github.com/dicej/wasm-tools?branch=lazy-adapter-stack-backport#cbfe4f297c689581374ce9b14f472c7cd560664b"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindge
 byte-array = { path = "byte-array" }
 
 [build-dependencies]
-wasm-encoder = "0.22.1"
+wasm-encoder = "0.23"
 object = { version = "0.29.0", default-features = false, features = ["archive"] }
 
 [lib]

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
 
     let (wasi, _instance) = WasiCommand::instantiate_async(&mut store, &component, &linker).await?;
 
-    let result: Result<(), ()> = wasi.command(&mut store, 0, 1, &[], &[], &[]).await?;
+    let result: Result<(), ()> = wasi.call_command(&mut store, 0, 1, &[], &[], &[]).await?;
 
     if result.is_err() {
         anyhow::bail!("command returned with failing exit status");

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -640,3 +640,16 @@ async fn run_truncation_rights(store: Store<WasiCtx>, wasi: WasiCommand) -> Resu
 async fn run_unlink_file_trailing_slashes(store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     expect_fail(run_with_temp_dir(store, wasi).await)
 }
+
+async fn run_export_cabi_realloc(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
+    wasi.command(
+        &mut store,
+        0 as InputStream,
+        1 as OutputStream,
+        &[],
+        &[],
+        &[],
+    )
+    .await?
+    .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
+}

--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -51,7 +51,7 @@ async fn instantiate(path: &str) -> Result<(Store<WasiCtx>, WasiCommand)> {
 }
 
 async fn run_hello_stdout(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as InputStream,
         1 as OutputStream,
@@ -65,7 +65,7 @@ async fn run_hello_stdout(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Resul
 
 async fn run_panic(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     let r = wasi
-        .command(
+        .call_command(
             &mut store,
             0 as InputStream,
             1 as OutputStream,
@@ -89,7 +89,7 @@ async fn run_panic(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
 }
 
 async fn run_args(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as InputStream,
         1 as OutputStream,
@@ -124,7 +124,7 @@ async fn run_random(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> 
 
     store.data_mut().random = Box::new(FakeRng);
 
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as InputStream,
         1 as OutputStream,
@@ -181,7 +181,7 @@ async fn run_time(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     store.data_mut().clocks.default_monotonic_clock =
         Box::new(FakeMonotonicClock { now: Mutex::new(0) });
 
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as InputStream,
         1 as OutputStream,
@@ -200,7 +200,7 @@ async fn run_stdin(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
             "So rested he by the Tumtum tree",
         ))));
 
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as InputStream,
         1 as OutputStream,
@@ -219,7 +219,7 @@ async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<
             "So rested he by the Tumtum tree",
         ))));
 
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as InputStream,
         1 as OutputStream,
@@ -232,7 +232,7 @@ async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<
 }
 
 async fn run_env(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as Descriptor,
         1 as Descriptor,
@@ -257,7 +257,7 @@ async fn run_file_read(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<(
                 open_dir,
             )))?;
 
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as Descriptor,
         1 as Descriptor,
@@ -283,7 +283,7 @@ async fn run_file_append(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result
                 open_dir,
             )))?;
 
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as Descriptor,
         1 as Descriptor,
@@ -319,7 +319,7 @@ async fn run_file_dir_sync(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Resu
                 open_dir,
             )))?;
 
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as Descriptor,
         1 as Descriptor,
@@ -333,7 +333,7 @@ async fn run_file_dir_sync(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Resu
 
 async fn run_exit_success(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     let r = wasi
-        .command(
+        .call_command(
             &mut store,
             0 as Descriptor,
             1 as Descriptor,
@@ -350,7 +350,7 @@ async fn run_exit_success(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Resul
 
 async fn run_exit_default(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     let r = wasi
-        .command(
+        .call_command(
             &mut store,
             0 as Descriptor,
             1 as Descriptor,
@@ -365,7 +365,7 @@ async fn run_exit_default(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Resul
 
 async fn run_exit_failure(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     let r = wasi
-        .command(
+        .call_command(
             &mut store,
             0 as Descriptor,
             1 as Descriptor,
@@ -382,7 +382,7 @@ async fn run_exit_failure(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Resul
 
 async fn run_exit_panic(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
     let r = wasi
-        .command(
+        .call_command(
             &mut store,
             0 as Descriptor,
             1 as Descriptor,
@@ -415,7 +415,7 @@ async fn run_directory_list(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Res
                 open_dir,
             )))?;
 
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as Descriptor,
         1 as Descriptor,
@@ -428,7 +428,7 @@ async fn run_directory_list(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Res
 }
 
 async fn run_default_clocks(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    wasi.command(&mut store, 0 as Descriptor, 1 as Descriptor, &[], &[], &[])
+    wasi.call_command(&mut store, 0 as Descriptor, 1 as Descriptor, &[], &[], &[])
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -444,7 +444,7 @@ async fn run_with_temp_dir(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Resu
                 open_dir,
             )))?;
 
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as InputStream,
         1 as OutputStream,
@@ -642,7 +642,7 @@ async fn run_unlink_file_trailing_slashes(store: Store<WasiCtx>, wasi: WasiComma
 }
 
 async fn run_export_cabi_realloc(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
-    wasi.command(
+    wasi.call_command(
         &mut store,
         0 as InputStream,
         1 as OutputStream,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ pub unsafe extern "C" fn environ_sizes_get(
     environ_buf_size: *mut Size,
 ) -> Errno {
     if matches!(
-        unsafe { get_allocation_state() },
+        get_allocation_state(),
         AllocationState::StackAllocated | AllocationState::StateAllocated
     ) {
         State::with(|state| {
@@ -325,7 +325,7 @@ pub unsafe extern "C" fn clock_time_get(
     time: &mut Timestamp,
 ) -> Errno {
     if matches!(
-        unsafe { get_allocation_state() },
+        get_allocation_state(),
         AllocationState::StackAllocated | AllocationState::StateAllocated
     ) {
         State::with(|state| {
@@ -679,7 +679,7 @@ fn get_preopen(state: &State, fd: Fd) -> Option<&Preopen> {
 #[no_mangle]
 pub unsafe extern "C" fn fd_prestat_get(fd: Fd, buf: *mut Prestat) -> Errno {
     if matches!(
-        unsafe { get_allocation_state() },
+        get_allocation_state(),
         AllocationState::StackAllocated | AllocationState::StateAllocated
     ) {
         State::with(|state| {
@@ -1789,7 +1789,7 @@ pub unsafe extern "C" fn sched_yield() -> Errno {
 #[no_mangle]
 pub unsafe extern "C" fn random_get(buf: *mut u8, buf_len: Size) -> Errno {
     if matches!(
-        unsafe { get_allocation_state() },
+        get_allocation_state(),
         AllocationState::StackAllocated | AllocationState::StateAllocated
     ) {
         State::with(|state| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,23 +263,32 @@ pub unsafe extern "C" fn environ_sizes_get(
     environc: *mut Size,
     environ_buf_size: *mut Size,
 ) -> Errno {
-    State::with(|state| {
-        if let Some(list) = state.env_vars {
-            *environc = list.len();
-            *environ_buf_size = {
-                let mut sum = 0;
-                for pair in list {
-                    sum += pair.key.len + pair.value.len + 2;
-                }
-                sum
-            };
-        } else {
-            *environc = 0;
-            *environ_buf_size = 0;
-        }
+    if matches!(
+        unsafe { get_allocation_state() },
+        AllocationState::StackAllocated | AllocationState::StateAllocated
+    ) {
+        State::with(|state| {
+            if let Some(list) = state.env_vars {
+                *environc = list.len();
+                *environ_buf_size = {
+                    let mut sum = 0;
+                    for pair in list {
+                        sum += pair.key.len + pair.value.len + 2;
+                    }
+                    sum
+                };
+            } else {
+                *environc = 0;
+                *environ_buf_size = 0;
+            }
 
-        Ok(())
-    })
+            Ok(())
+        })
+    } else {
+        *environc = 0;
+        *environ_buf_size = 0;
+        ERRNO_SUCCESS
+    }
 }
 
 /// Return the resolution of a clock.
@@ -315,22 +324,30 @@ pub unsafe extern "C" fn clock_time_get(
     _precision: Timestamp,
     time: &mut Timestamp,
 ) -> Errno {
-    State::with(|state| {
-        match id {
-            CLOCKID_MONOTONIC => {
-                *time = wasi_clocks::monotonic_clock_now(state.default_monotonic_clock());
+    if matches!(
+        unsafe { get_allocation_state() },
+        AllocationState::StackAllocated | AllocationState::StateAllocated
+    ) {
+        State::with(|state| {
+            match id {
+                CLOCKID_MONOTONIC => {
+                    *time = wasi_clocks::monotonic_clock_now(state.default_monotonic_clock());
+                }
+                CLOCKID_REALTIME => {
+                    let res = wasi_clocks::wall_clock_now(state.default_wall_clock());
+                    *time = Timestamp::from(res.nanoseconds)
+                        .checked_add(res.seconds)
+                        .and_then(|secs| secs.checked_mul(1_000_000_000))
+                        .ok_or(ERRNO_OVERFLOW)?;
+                }
+                _ => unreachable!(),
             }
-            CLOCKID_REALTIME => {
-                let res = wasi_clocks::wall_clock_now(state.default_wall_clock());
-                *time = Timestamp::from(res.nanoseconds)
-                    .checked_add(res.seconds)
-                    .and_then(|secs| secs.checked_mul(1_000_000_000))
-                    .ok_or(ERRNO_OVERFLOW)?;
-            }
-            _ => unreachable!(),
-        }
-        Ok(())
-    })
+            Ok(())
+        })
+    } else {
+        *time = Timestamp::from(0u64);
+        ERRNO_SUCCESS
+    }
 }
 
 /// Provide file advisory information on a file descriptor.
@@ -661,22 +678,29 @@ fn get_preopen(state: &State, fd: Fd) -> Option<&Preopen> {
 /// Return a description of the given preopened file descriptor.
 #[no_mangle]
 pub unsafe extern "C" fn fd_prestat_get(fd: Fd, buf: *mut Prestat) -> Errno {
-    State::with(|state| {
-        if let Some(preopen) = get_preopen(state, fd) {
-            buf.write(Prestat {
-                tag: 0,
-                u: PrestatU {
-                    dir: PrestatDir {
-                        pr_name_len: preopen.path.len,
+    if matches!(
+        unsafe { get_allocation_state() },
+        AllocationState::StackAllocated | AllocationState::StateAllocated
+    ) {
+        State::with(|state| {
+            if let Some(preopen) = get_preopen(state, fd) {
+                buf.write(Prestat {
+                    tag: 0,
+                    u: PrestatU {
+                        dir: PrestatDir {
+                            pr_name_len: preopen.path.len,
+                        },
                     },
-                },
-            });
+                });
 
-            Ok(())
-        } else {
-            Err(ERRNO_BADF)
-        }
-    })
+                Ok(())
+            } else {
+                Err(ERRNO_BADF)
+            }
+        })
+    } else {
+        ERRNO_BADF
+    }
 }
 
 /// Return a description of the given preopened file descriptor.
@@ -1445,7 +1469,8 @@ impl From<wasi_tcp::Errno> for Errno {
             HostUnreachable => ERRNO_HOSTUNREACH,
             NetworkDown => ERRNO_NETDOWN,
             NetworkUnreachable => ERRNO_NETUNREACH,
-            Timeout => ERRNO_TIMEDOUT,
+            Timedout => ERRNO_TIMEDOUT,
+            _ => unreachable!(),
         }
     }
 }
@@ -1763,19 +1788,26 @@ pub unsafe extern "C" fn sched_yield() -> Errno {
 /// number generator, rather than to provide the random data directly.
 #[no_mangle]
 pub unsafe extern "C" fn random_get(buf: *mut u8, buf_len: Size) -> Errno {
-    State::with(|state| {
-        state.register_buffer(buf, buf_len);
+    if matches!(
+        unsafe { get_allocation_state() },
+        AllocationState::StackAllocated | AllocationState::StateAllocated
+    ) {
+        State::with(|state| {
+            state.register_buffer(buf, buf_len);
 
-        assert_eq!(buf_len as u32 as Size, buf_len);
-        let result = wasi_random::get_random_bytes(buf_len as u32);
-        assert_eq!(result.as_ptr(), buf);
+            assert_eq!(buf_len as u32 as Size, buf_len);
+            let result = wasi_random::get_random_bytes(buf_len as u32);
+            assert_eq!(result.as_ptr(), buf);
 
-        // The returned buffer's memory was allocated in `buf`, so don't separately
-        // free it.
-        forget(result);
+            // The returned buffer's memory was allocated in `buf`, so don't separately
+            // free it.
+            forget(result);
 
-        Ok(())
-    })
+            Ok(())
+        })
+    } else {
+        ERRNO_SUCCESS
+    }
 }
 
 /// Accept a new incoming connection.
@@ -2197,10 +2229,22 @@ const _: () = {
     let _size_assert: [(); PAGE_SIZE] = [(); size_of::<RefCell<State>>()];
 };
 
+#[allow(unused)]
+#[repr(i32)]
+enum AllocationState {
+    StackUnallocated,
+    StackAllocating,
+    StackAllocated,
+    StateAllocating,
+    StateAllocated,
+}
+
 #[allow(improper_ctypes)]
 extern "C" {
-    fn get_global_ptr() -> *const RefCell<State>;
-    fn set_global_ptr(a: *const RefCell<State>);
+    fn get_state_ptr() -> *const RefCell<State>;
+    fn set_state_ptr(state: *const RefCell<State>);
+    fn get_allocation_state() -> AllocationState;
+    fn set_allocation_state(state: AllocationState);
 }
 
 impl State {
@@ -2230,10 +2274,10 @@ impl State {
 
     fn ptr() -> &'static RefCell<State> {
         unsafe {
-            let mut ptr = get_global_ptr();
+            let mut ptr = get_state_ptr();
             if ptr.is_null() {
                 ptr = State::new();
-                set_global_ptr(ptr);
+                set_state_ptr(ptr);
             }
             &*ptr
         }
@@ -2251,6 +2295,13 @@ impl State {
             ) -> *mut u8;
         }
 
+        assert!(matches!(
+            unsafe { get_allocation_state() },
+            AllocationState::StackAllocated
+        ));
+
+        unsafe { set_allocation_state(AllocationState::StateAllocating) };
+
         let ret = unsafe {
             cabi_realloc(
                 ptr::null_mut(),
@@ -2259,6 +2310,8 @@ impl State {
                 mem::size_of::<RefCell<State>>(),
             ) as *mut RefCell<State>
         };
+
+        unsafe { set_allocation_state(AllocationState::StateAllocated) };
 
         let ret = unsafe {
             ret.write(RefCell::new(State {

--- a/test-programs/macros/Cargo.toml
+++ b/test-programs/macros/Cargo.toml
@@ -13,5 +13,4 @@ test = false
 quote = "1.0"
 
 [build-dependencies]
-# TODO: switch to a release once https://github.com/bytecodealliance/wasm-tools/pull/919 has been merged
-wit-component = { git = "https://github.com/dicej/wasm-tools", branch = "lazy-adapter-stack-backport" }
+wit-component = "0.6.0"

--- a/test-programs/macros/Cargo.toml
+++ b/test-programs/macros/Cargo.toml
@@ -13,4 +13,5 @@ test = false
 quote = "1.0"
 
 [build-dependencies]
-wit-component = "0.5.1"
+# TODO: switch to a release once https://github.com/bytecodealliance/wasm-tools/pull/919 has been merged
+wit-component = { git = "https://github.com/dicej/wasm-tools", branch = "lazy-adapter-stack-backport" }

--- a/test-programs/src/bin/export_cabi_realloc.rs
+++ b/test-programs/src/bin/export_cabi_realloc.rs
@@ -1,0 +1,34 @@
+//! `wit-component` handles modules which export `cabi_realloc` in a special way, using it instead of `memory.grow`
+//! to allocate the adapter stack, hence this test.
+
+#[export_name = "cabi_realloc"]
+#[no_mangle]
+unsafe extern "C" fn cabi_realloc(
+    old_ptr: *mut u8,
+    old_len: usize,
+    align: usize,
+    new_len: usize,
+) -> *mut u8 {
+    use std::alloc::{self, Layout};
+
+    let layout;
+    let ptr = if old_len == 0 {
+        if new_len == 0 {
+            return align as *mut u8;
+        }
+        layout = Layout::from_size_align_unchecked(new_len, align);
+        alloc::alloc(layout)
+    } else {
+        debug_assert_ne!(new_len, 0, "non-zero old_len requires non-zero new_len!");
+        layout = Layout::from_size_align_unchecked(old_len, align);
+        alloc::realloc(old_ptr, layout, new_len)
+    };
+    if ptr.is_null() {
+        core::arch::wasm32::unreachable();
+    }
+    return ptr;
+}
+
+fn main() {
+    println!("hello, world");
+}


### PR DESCRIPTION
Per https://github.com/bytecodealliance/wasm-tools/pull/919, `wit-component` needs to lazily allocate the adapter stack to avoid premature or infinite reentrance from the main module to the adapter. This means adding an additional `allocation_state` global variable and using it to determine when to return early from an exported function, e.g. because we're in the process of either allocating the stack or allocating `State`.

This requires an updated `wit-component` dependency once https://github.com/bytecodealliance/wasm-tools/pull/919 has been merged.

Fixes #78

Signed-off-by: Joel Dice <joel.dice@fermyon.com>