### PR TITLE
Fix timestamp-to-nanosecond conversion in the adapter

### DIFF
--- a/host/tests/runtime.rs
+++ b/host/tests/runtime.rs
@@ -132,7 +132,7 @@ async fn run_time(mut store: Store<WasiCtx>, wasi: WasiCommand) -> Result<()> {
         }
 
         fn now(&self) -> Duration {
-            Duration::from_secs(1431648000)
+            Duration::new(1431648000, 100)
         }
 
         fn dup(&self) -> Box<dyn WasiWallClock + Send + Sync> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,9 +378,9 @@ pub extern "C" fn clock_res_get(id: Clockid, resolution: &mut Timestamp) -> Errn
             }
             CLOCKID_REALTIME => {
                 let res = wasi_wall_clock::resolution(state.default_wall_clock());
-                *resolution = Timestamp::from(res.nanoseconds)
-                    .checked_add(res.seconds)
-                    .and_then(|secs| secs.checked_mul(1_000_000_000))
+                *resolution = Timestamp::from(res.seconds)
+                    .checked_mul(1_000_000_000)
+                    .and_then(|ns| ns.checked_add(res.nanoseconds.into()))
                     .ok_or(ERRNO_OVERFLOW)?;
             }
             _ => unreachable!(),
@@ -408,9 +408,9 @@ pub unsafe extern "C" fn clock_time_get(
                 }
                 CLOCKID_REALTIME => {
                     let res = wasi_wall_clock::now(state.default_wall_clock());
-                    *time = Timestamp::from(res.nanoseconds)
-                        .checked_add(res.seconds)
-                        .and_then(|secs| secs.checked_mul(1_000_000_000))
+                    *time = Timestamp::from(res.seconds)
+                        .checked_mul(1_000_000_000)
+                        .and_then(|ns| ns.checked_add(res.nanoseconds.into()))
                         .ok_or(ERRNO_OVERFLOW)?;
                 }
                 _ => unreachable!(),

--- a/test-programs/src/bin/time.rs
+++ b/test-programs/src/bin/time.rs
@@ -6,7 +6,7 @@ fn main() {
     assert_eq!(Duration::from_secs(42), then.elapsed());
 
     assert_eq!(
-        SystemTime::UNIX_EPOCH + Duration::from_secs(1431648000),
+        SystemTime::UNIX_EPOCH + Duration::new(1431648000, 100),
         SystemTime::now()
     );
 }


### PR DESCRIPTION
The order of operations for handling the seconds/nanoseconds part of the structure were a bit off which meant that a nonzero nanosecond field would have an unexpected effect on the result.

Closes #92