### PR TITLE
Make `read-via-stream` etc. infallible.

### DIFF
--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -761,7 +761,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         let f = self.table_mut().get_file_mut(fd).map_err(convert)?;
 
         // Duplicate the file descriptor so that we get an indepenent lifetime.
-        let clone = f.try_clone().await.map_err(convert)?;
+        let clone = f.dup();
 
         // Create a stream view for it.
         let reader = FileStream::new_reader(clone, offset);
@@ -783,7 +783,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         let f = self.table_mut().get_file_mut(fd).map_err(convert)?;
 
         // Duplicate the file descriptor so that we get an indepenent lifetime.
-        let clone = f.try_clone().await.map_err(convert)?;
+        let clone = f.dup();
 
         // Create a stream view for it.
         let writer = FileStream::new_writer(clone, offset);
@@ -804,7 +804,7 @@ impl wasi_filesystem::WasiFilesystem for WasiCtx {
         let f = self.table_mut().get_file_mut(fd).map_err(convert)?;
 
         // Duplicate the file descriptor so that we get an indepenent lifetime.
-        let clone = f.try_clone().await.map_err(convert)?;
+        let clone = f.dup();
 
         // Create a stream view for it.
         let appender = FileStream::new_appender(clone);

--- a/wasi-common/cap-std-sync/src/file.rs
+++ b/wasi-common/cap-std-sync/src/file.rs
@@ -5,6 +5,7 @@ use is_terminal::IsTerminal;
 use std::any::Any;
 use std::convert::TryInto;
 use std::io;
+use std::sync::Arc;
 use system_interface::fs::{FileIoExt, GetSetFdFlags};
 use system_interface::io::IsReadWrite;
 use wasi_common::{
@@ -14,11 +15,15 @@ use wasi_common::{
 #[cfg(windows)]
 use windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED;
 
-pub struct File(cap_std::fs::File);
+/// A file handle.
+///
+/// We hold an `Arc` so that stream views can be regular handles which can
+/// be closed, without closing the underlying file descriptor.
+pub struct File(Arc<cap_std::fs::File>);
 
 impl File {
     pub fn from_cap_std(file: cap_std::fs::File) -> Self {
-        File(file)
+        File(Arc::new(file))
     }
 }
 
@@ -35,11 +40,6 @@ impl WasiFile for File {
     #[cfg(windows)]
     fn pollable(&self) -> Option<io_extras::os::windows::BorrowedHandleOrSocket> {
         Some(self.0.as_handle_or_socket())
-    }
-
-    async fn try_clone(&mut self) -> Result<Box<dyn WasiFile>, Error> {
-        let clone = self.0.try_clone()?;
-        Ok(Box::new(Self(clone)))
     }
 
     async fn datasync(&self) -> Result<(), Error> {
@@ -76,18 +76,6 @@ impl WasiFile for File {
     async fn get_fdflags(&self) -> Result<FdFlags, Error> {
         let fdflags = get_fd_flags(&self.0)?;
         Ok(fdflags)
-    }
-    async fn set_fdflags(&mut self, fdflags: FdFlags) -> Result<(), Error> {
-        if fdflags.intersects(
-            wasi_common::file::FdFlags::DSYNC
-                | wasi_common::file::FdFlags::SYNC
-                | wasi_common::file::FdFlags::RSYNC,
-        ) {
-            return Err(Error::invalid_argument().context("cannot set DSYNC, SYNC, or RSYNC flag"));
-        }
-        let set_fd_flags = self.0.new_set_fd_flags(to_sysif_fdflags(fdflags))?;
-        self.0.set_fd_flags(set_fd_flags)?;
-        Ok(())
     }
     async fn get_filestat(&self) -> Result<Filestat, Error> {
         let meta = self.0.metadata()?;
@@ -191,6 +179,10 @@ impl WasiFile for File {
             Err(Error::badf())
         }
     }
+
+    fn dup(&self) -> Box<dyn WasiFile> {
+        Box::new(File(Arc::clone(&self.0)))
+    }
 }
 
 pub fn filetype_from(ft: &cap_std::fs::FileType) -> FileType {
@@ -255,26 +247,6 @@ pub(crate) fn convert_systimespec(
         Some(wasi_common::SystemTimeSpec::SymbolicNow) => Some(SystemTimeSpec::SymbolicNow),
         None => None,
     }
-}
-
-pub(crate) fn to_sysif_fdflags(f: wasi_common::file::FdFlags) -> system_interface::fs::FdFlags {
-    let mut out = system_interface::fs::FdFlags::empty();
-    if f.contains(wasi_common::file::FdFlags::APPEND) {
-        out |= system_interface::fs::FdFlags::APPEND;
-    }
-    if f.contains(wasi_common::file::FdFlags::DSYNC) {
-        out |= system_interface::fs::FdFlags::DSYNC;
-    }
-    if f.contains(wasi_common::file::FdFlags::NONBLOCK) {
-        out |= system_interface::fs::FdFlags::NONBLOCK;
-    }
-    if f.contains(wasi_common::file::FdFlags::RSYNC) {
-        out |= system_interface::fs::FdFlags::RSYNC;
-    }
-    if f.contains(wasi_common::file::FdFlags::SYNC) {
-        out |= system_interface::fs::FdFlags::SYNC;
-    }
-    out
 }
 
 /// Return the file-descriptor flags for a given file-like object.

--- a/wasi-common/cap-std-sync/src/file.rs
+++ b/wasi-common/cap-std-sync/src/file.rs
@@ -74,7 +74,7 @@ impl WasiFile for File {
         Ok(filetype_from(&meta.file_type()))
     }
     async fn get_fdflags(&self) -> Result<FdFlags, Error> {
-        let fdflags = get_fd_flags(&self.0)?;
+        let fdflags = get_fd_flags(&*self.0)?;
         Ok(fdflags)
     }
     async fn get_filestat(&self) -> Result<Filestat, Error> {
@@ -165,7 +165,7 @@ impl WasiFile for File {
     }
 
     async fn readable(&self) -> Result<(), Error> {
-        if is_read_write(&self.0)?.0 {
+        if is_read_write(&*self.0)?.0 {
             Ok(())
         } else {
             Err(Error::badf())
@@ -173,7 +173,7 @@ impl WasiFile for File {
     }
 
     async fn writable(&self) -> Result<(), Error> {
-        if is_read_write(&self.0)?.1 {
+        if is_read_write(&*self.0)?.1 {
             Ok(())
         } else {
             Err(Error::badf())

--- a/wasi-common/src/file.rs
+++ b/wasi-common/src/file.rs
@@ -22,10 +22,6 @@ pub trait WasiFile: Send + Sync {
         false
     }
 
-    async fn try_clone(&mut self) -> Result<Box<dyn WasiFile>, Error> {
-        Err(Error::badf())
-    }
-
     async fn datasync(&self) -> Result<(), Error>;
 
     async fn sync(&self) -> Result<(), Error>;
@@ -118,6 +114,8 @@ pub trait WasiFile: Send + Sync {
     async fn readable(&self) -> Result<(), Error>;
 
     async fn writable(&self) -> Result<(), Error>;
+
+    fn dup(&self) -> Box<dyn WasiFile>;
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Wrap `File`'s contents in an `Arc` so that file handles and stream handles can share the underlying file descriptor, so that we don't have to call `try_clone()`. This avoids the possibility of `try_clone()` failing.

This also makes `File` similar to `Dir`, which already has an `Arc`, in preparation for merging `File` and `Dir` now that WASI has decided that file and directory shouldn't be separate types.