### PR TITLE
remove preopens argument from the cli command function

### DIFF
--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
 
     let (wasi, _instance) = Cli::instantiate_async(&mut store, &component, &linker).await?;
 
-    let result: Result<(), ()> = wasi.call_command(&mut store, 0, 1, 2, &[], &[]).await?;
+    let result: Result<(), ()> = wasi.call_command(&mut store, 0, 1, 2, &[]).await?;
 
     if result.is_err() {
         anyhow::bail!("command returned with failing exit status");

--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -57,7 +57,6 @@ async fn run_hello_stdout(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         1 as OutputStream,
         2 as OutputStream,
         &["gussie", "sparky", "willa"],
-        &[],
     )
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
@@ -80,7 +79,6 @@ async fn run_panic(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
                 "good",
                 "yesterday",
             ],
-            &[],
         )
         .await;
     assert!(r.is_err());
@@ -95,7 +93,6 @@ async fn run_args(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         1 as OutputStream,
         2 as OutputStream,
         &["hello", "this", "", "is an argument", "with 🚩 emoji"],
-        &[],
     )
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
@@ -129,7 +126,6 @@ async fn run_random(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         0 as InputStream,
         1 as OutputStream,
         2 as OutputStream,
-        &[],
         &[],
     )
     .await?
@@ -187,7 +183,6 @@ async fn run_time(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         1 as OutputStream,
         2 as OutputStream,
         &[],
-        &[],
     )
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
@@ -205,7 +200,6 @@ async fn run_stdin(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         0 as InputStream,
         1 as OutputStream,
         2 as OutputStream,
-        &[],
         &[],
     )
     .await?
@@ -225,7 +219,6 @@ async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         1 as OutputStream,
         2 as OutputStream,
         &[],
-        &[],
     )
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
@@ -239,7 +232,6 @@ async fn run_env(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         0 as Descriptor,
         1 as Descriptor,
         2 as OutputStream,
-        &[],
         &[],
     )
     .await?
@@ -263,7 +255,6 @@ async fn run_file_read(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         1 as Descriptor,
         2 as OutputStream,
         &[],
-        &[],
     )
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
@@ -286,7 +277,6 @@ async fn run_file_append(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         0 as Descriptor,
         1 as Descriptor,
         2 as OutputStream,
-        &[],
         &[],
     )
     .await?
@@ -321,7 +311,6 @@ async fn run_file_dir_sync(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         1 as Descriptor,
         2 as OutputStream,
         &[],
-        &[],
     )
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
@@ -334,7 +323,6 @@ async fn run_exit_success(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
             0 as Descriptor,
             1 as Descriptor,
             2 as OutputStream,
-            &[],
             &[],
         )
         .await;
@@ -352,7 +340,6 @@ async fn run_exit_default(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
             1 as Descriptor,
             2 as OutputStream,
             &[],
-            &[],
         )
         .await?;
     assert!(r.is_ok());
@@ -366,7 +353,6 @@ async fn run_exit_failure(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
             0 as Descriptor,
             1 as Descriptor,
             2 as OutputStream,
-            &[],
             &[],
         )
         .await;
@@ -383,7 +369,6 @@ async fn run_exit_panic(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
             0 as Descriptor,
             1 as Descriptor,
             2 as OutputStream,
-            &[],
             &[],
         )
         .await;
@@ -415,7 +400,6 @@ async fn run_directory_list(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> 
         1 as Descriptor,
         2 as OutputStream,
         &[],
-        &[],
     )
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
@@ -427,7 +411,6 @@ async fn run_default_clocks(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> 
         0 as Descriptor,
         1 as Descriptor,
         2 as OutputStream,
-        &[],
         &[],
     )
     .await?
@@ -451,7 +434,6 @@ async fn run_with_temp_dir(mut store: Store<WasiCtx>, wasi: Cli) -> Result<()> {
         1 as OutputStream,
         2 as OutputStream,
         &["program", "/foo"],
-        &[],
     )
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
@@ -643,7 +625,6 @@ async fn run_export_cabi_realloc(mut store: Store<WasiCtx>, wasi: Cli) -> Result
         0 as InputStream,
         1 as OutputStream,
         2 as OutputStream,
-        &[],
         &[],
     )
     .await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@ pub unsafe extern "C" fn command(
     stderr: OutputStream,
     args_ptr: *const WasmStr,
     args_len: usize,
-    preopens: PreopenList,
 ) -> u32 {
     State::with_mut(|state| {
         // Initialization of `State` automatically fills in some dummy

--- a/wit/cli.wit
+++ b/wit/cli.wit
@@ -28,6 +28,5 @@ default world cli {
     stdout: output-stream,
     stderr: output-stream,
     args: list<string>,
-    preopens: list<tuple<descriptor, string>>,
   ) -> result
 }


### PR DESCRIPTION
This argument never got plumbed through, and I don't think it should be in here in a non-working state.