### PR TITLE
drop cli- prefix from reactor, command features & artifact names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,20 +45,20 @@ jobs:
     - run: rustup target add --toolchain=stable wasm32-wasi wasm32-unknown-unknown
     - run: rustup target add --toolchain=nightly wasm32-wasi wasm32-unknown-unknown
 
-      # Debug build, default features (cli-reactor)
+      # Debug build, default features (reactor)
     - run: cargo build --target wasm32-unknown-unknown
     - run: cargo run -p verify -- ./target/wasm32-unknown-unknown/debug/wasi_snapshot_preview1.wasm
 
-      # Debug build, cli-command
-    - run: cargo build --target wasm32-unknown-unknown --no-default-features --features cli-command
+      # Debug build, command
+    - run: cargo build --target wasm32-unknown-unknown --no-default-features --features command
     - run: cargo run -p verify -- ./target/wasm32-unknown-unknown/debug/wasi_snapshot_preview1.wasm
 
-      # Release build, default features (cli-reactor)
+      # Release build, default features (reactor)
     - run: cargo build --release --target wasm32-unknown-unknown
     - run: cargo run -p verify -- ./target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm
 
-      # Release build, cli-command
-    - run: cargo build --release --target wasm32-unknown-unknown --no-default-features --features cli-command
+      # Release build, command
+    - run: cargo build --release --target wasm32-unknown-unknown --no-default-features --features command
     - run: cargo run -p verify -- ./target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm
 
     - run: cargo test -p host
@@ -74,21 +74,21 @@ jobs:
     - run: rustup update stable && rustup default stable
     - run: rustup target add wasm32-wasi wasm32-unknown-unknown
 
-    # Release build, cli-command
-    - run: cargo build --target wasm32-unknown-unknown --release --no-default-features --features cli-command
-    - run: mv target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm wasi_snapshot_preview1.cli_command.wasm
+    # Release build, command
+    - run: cargo build --target wasm32-unknown-unknown --release --no-default-features --features command
+    - run: mv target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm wasi_snapshot_preview1.command.wasm
     - uses: actions/upload-artifact@v3
       with:
-        name: wasi_snapshot_preview1.cli_command.wasm
-        path: wasi_snapshot_preview1.cli_command.wasm
+        name: wasi_snapshot_preview1.command.wasm
+        path: wasi_snapshot_preview1.command.wasm
 
-    # Release build, default features (cli-reactor)
+    # Release build, default features (reactor)
     - run: cargo build --target wasm32-unknown-unknown --release
-    - run: mv target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm wasi_snapshot_preview1.cli_reactor.wasm
+    - run: mv target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.wasm wasi_snapshot_preview1.reactor.wasm
     - uses: actions/upload-artifact@v3
       with:
-        name: wasi_snapshot_preview1.cli_reactor.wasm
-        path: target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.cli_reactor.wasm
+        name: wasi_snapshot_preview1.reactor.wasm
+        path: target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.reactor.wasm
 
     - run: |
         curl -L https://github.com/bytecodealliance/wit-bindgen/releases/download/wit-bindgen-cli-0.4.0/wit-bindgen-v0.4.0-x86_64-linux.tar.gz | tar xfz -
@@ -120,8 +120,8 @@ jobs:
         prerelease: true
         title: "Latest Build"
         files: |
-          wasi_snapshot_preview1.cli_reactor.wasm
-          wasi_snapshot_preview1.cli_command.wasm
+          wasi_snapshot_preview1.reactor.wasm
+          wasi_snapshot_preview1.command.wasm
           cli.c
           cli.h
           cli_component_type.o

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ debug-assertions = false
 overflow-checks = false
 
 [features]
-default = ["cli-reactor"]
-cli-reactor = []
-cli-command = []
+default = ["reactor"]
+reactor = []
+command = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,16 +16,14 @@ use poll::Pollable;
 use streams::{InputStream, OutputStream};
 use wasi::*;
 
-#[cfg(all(feature = "cli-command", feature = "cli-reactor"))]
-compile_error!(
-    "only one of the `cli-command` and `cli-reactor` features may be selected at a time"
-);
+#[cfg(all(feature = "command", feature = "reactor"))]
+compile_error!("only one of the `command` and `reactor` features may be selected at a time");
 
 #[macro_use]
 mod macros;
 
 mod bindings {
-    #[cfg(feature = "cli-command")]
+    #[cfg(feature = "command")]
     wit_bindgen::generate!({
         world: "command",
         std_feature,
@@ -35,7 +33,7 @@ mod bindings {
         skip: ["main", "preopens", "get-environment"],
     });
 
-    #[cfg(feature = "cli-reactor")]
+    #[cfg(feature = "reactor")]
     wit_bindgen::generate!({
         world: "reactor",
         std_feature,
@@ -45,7 +43,7 @@ mod bindings {
 }
 
 #[no_mangle]
-#[cfg(feature = "cli-command")]
+#[cfg(feature = "command")]
 pub unsafe extern "C" fn main(
     stdin: InputStream,
     stdout: OutputStream,
@@ -254,7 +252,7 @@ impl ImportAlloc {
 
 /// This allocator is only used for the `main` entrypoint.
 ///
-/// The implementation here is a bump allocator into `State::command_data` which
+/// The implementation here is a bump allocator into `State::long_lived_arena` which
 /// traps when it runs out of data. This means that the total size of
 /// arguments/env/etc coming into a component is bounded by the current 64k
 /// (ish) limit. That's just an implementation limit though which can be lifted

--- a/test-programs/macros/build.rs
+++ b/test-programs/macros/build.rs
@@ -35,11 +35,9 @@ fn build_adapter(name: &str, features: &[&str]) -> Vec<u8> {
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    let cli_reactor_adapter = build_adapter("cli_reactor", &[]);
-    let cli_command_adapter = build_adapter(
-        "cli_command",
-        &["--no-default-features", "--features=cli-command"],
-    );
+    let reactor_adapter = build_adapter("reactor", &[]);
+    let command_adapter =
+        build_adapter("command", &["--no-default-features", "--features=command"]);
 
     // Build all test program crates
     // wasi-tests and test-programs require nightly for a feature in the `errno` crate
@@ -92,7 +90,7 @@ fn main() {
             .module(module.as_slice())
             .unwrap()
             .validate(true)
-            .adapter("wasi_snapshot_preview1", &cli_command_adapter)
+            .adapter("wasi_snapshot_preview1", &command_adapter)
             .unwrap()
             .encode()
             .expect(&format!(
@@ -117,7 +115,7 @@ fn main() {
             .module(module.as_slice())
             .unwrap()
             .validate(true)
-            .adapter("wasi_snapshot_preview1", &cli_reactor_adapter)
+            .adapter("wasi_snapshot_preview1", &reactor_adapter)
             .unwrap()
             .encode()
             .expect(&format!(


### PR DESCRIPTION
Naming consistency follow-up on #106 