### PR TITLE
Assertion failure in wit-component on testcase calling preview2 APIs directly

### DIFF
--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -674,3 +674,16 @@ async fn run_export_cabi_realloc(mut store: Store<WasiCtx>, wasi: Command) -> Re
     .await?
     .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
+
+async fn run_small(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
+    wasi.call_main(
+        &mut store,
+        0 as InputStream,
+        1 as OutputStream,
+        2 as OutputStream,
+        &[],
+        &[],
+    )
+    .await?
+    .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
+}

--- a/test-programs/src/bin/small.rs
+++ b/test-programs/src/bin/small.rs
@@ -1,0 +1,10 @@
+mod bindings {
+    wit_bindgen::generate!({
+        world: "little",
+        path: "../wit",
+    });
+}
+
+fn main() {
+    bindings::stderr::print("Hello, world\n");
+}

--- a/wit/little.wit
+++ b/wit/little.wit
@@ -1,0 +1,4 @@
+default world little {
+  import environment-preopens: pkg.environment-preopens
+  import stderr: pkg.stderr
+}


### PR DESCRIPTION
I'm looking to write a testcase that calls a preview2 API directly, but currently this hits an assertion failure in wit-component:

```
$ cargo test small
   Compiling test-programs-macros v0.0.0 (/test/preview2-prototyping/test-programs/macros)
error: failed to run custom build command for `test-programs-macros v0.0.0 (/test/preview2-prototyping/test-programs/macros)`

Caused by:
  process didn't exit successfully: `/test/preview2-prototyping/target/debug/build/test-programs-macros-1663b480010233e3/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=../../src
  wasi reactor adapter: "/test/preview2-prototyping/target/debug/build/test-programs-macros-6310714f5a0ccd73/out/wasi_snapshot_preview1.reactor.wasm"
  cargo:rerun-if-changed=../../src
  wasi command adapter: "/test/preview2-prototyping/target/debug/build/test-programs-macros-6310714f5a0ccd73/out/wasi_snapshot_preview1.command.wasm"
  cargo:rerun-if-changed=..

  --- stderr
     Compiling wasi_snapshot_preview1 v0.0.0 (/test)
      Finished release [optimized] target(s) in 1.67s
     Compiling wasi_snapshot_preview1 v0.0.0 (/test)
      Finished release [optimized] target(s) in 1.58s
      Finished dev [unoptimized + debuginfo] target(s) in 0.31s
      Finished dev [unoptimized + debuginfo] target(s) in 0.37s
  thread 'main' panicked at 'IndexMap: key not found', /home/.cargo/registry/src/github.com-1ecc6299db9ec823/wit-component-0.7.4/src/encoding.rs:518:32
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```