### PR TITLE
Have the runner inherit the host stderr.

### DIFF
--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -31,6 +31,7 @@ async fn main() -> Result<()> {
         WasiCtxBuilder::new()
             .inherit_stdin()
             .inherit_stdout()
+            .inherit_stderr()
             .build(),
     );
 

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -26,14 +26,7 @@ async fn main() -> Result<()> {
     let mut linker = Linker::new(&engine);
     add_to_linker(&mut linker, |x| x)?;
 
-    let mut store = Store::new(
-        &engine,
-        WasiCtxBuilder::new()
-            .inherit_stdin()
-            .inherit_stdout()
-            .inherit_stderr()
-            .build(),
-    );
+    let mut store = Store::new(&engine, WasiCtxBuilder::new().inherit_stdio().build());
 
     let (wasi, _instance) = Command::instantiate_async(&mut store, &component, &linker).await?;
 


### PR DESCRIPTION
Now that stderr is a stream, have the runner WasiCtx inherit the host stderr, so that guests can write to the stderr stream and it comes out through the host stderr.