### PR TITLE
chore: generate dummy component for preview2 worlds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,24 @@ jobs:
         path: target/wasm32-unknown-unknown/release/wasi_snapshot_preview1.reactor.wasm
 
     - run: |
+        curl -L https://github.com/bytecodealliance/wasm-tools/releases/download/wasm-tools-1.0.27/wasm-tools-1.0.27-x86_64-linux.tar.gz | tar xfz -
+        echo `pwd`/wasm-tools-1.0.27-x86_64-linux >> $GITHUB_PATH
+    - run: |
+      wasm-tools component embed --dummy ./wit/ -w command -o ./dummy_command.component.wasm
+      wasm-tools print ./dummy_command.component.wasm
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dummy_command.component.wasm
+        path: dummy_command.component.wasm
+    - run: |
+      wasm-tools component embed --dummy ./wit/ -w proxy -o ./dummy_proxy.component.wasm
+      wasm-tools print ./dummy_proxy.component.wasm
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dummy_proxy.component.wasm
+        path: dummy_proxy.component.wasm
+
+    - run: |
         curl -L https://github.com/bytecodealliance/wit-bindgen/releases/download/wit-bindgen-cli-0.4.0/wit-bindgen-v0.4.0-x86_64-linux.tar.gz | tar xfz -
         echo `pwd`/wit-bindgen-v0.4.0-x86_64-linux >> $GITHUB_PATH
     - run: wit-bindgen c ./wit --world command
@@ -128,3 +146,5 @@ jobs:
           cli.h
           cli_component_type.o
           cli.rs
+          dummy_command.component.wasm
+          dummy_proxy.component.wasm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,13 @@ jobs:
       with:
         name: dummy_proxy.component.wasm
         path: dummy_proxy.component.wasm
+    - run: |
+      wasm-tools component embed --dummy ./wit/ -w reactor -o ./dummy_reactor.component.wasm
+      wasm-tools print ./dummy_reactor.component.wasm
+    - uses: actions/upload-artifact@v3
+      with:
+        name: dummy_reactor.component.wasm
+        path: dummy_reactor.component.wasm
 
     - run: |
         curl -L https://github.com/bytecodealliance/wit-bindgen/releases/download/wit-bindgen-cli-0.4.0/wit-bindgen-v0.4.0-x86_64-linux.tar.gz | tar xfz -
@@ -148,3 +155,4 @@ jobs:
           cli.rs
           dummy_command.component.wasm
           dummy_proxy.component.wasm
+          dummy_reactor.component.wasm


### PR DESCRIPTION
This will generate a dummy component for `command`, `proxy` and `reactor` worlds and place them in the release. It will also print the WAT to stdout in GitHub actions.