### PR TITLE
Make args available through an import function rather than passed to command main

### DIFF
--- a/host/src/env.rs
+++ b/host/src/env.rs
@@ -6,6 +6,9 @@ impl wasi::environment::Host for WasiCtx {
     async fn get_environment(&mut self) -> anyhow::Result<Vec<(String, String)>> {
         Ok(self.env.clone())
     }
+    async fn get_arguments(&mut self) -> anyhow::Result<Vec<String>> {
+        Ok(self.args.clone())
+    }
 }
 
 #[async_trait::async_trait]

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -68,7 +68,7 @@ async fn run_command(
 
     let (wasi, _instance) = Command::instantiate_async(&mut store, component, linker).await?;
 
-    let result: Result<(), ()> = wasi.call_main(&mut store).await?;
+    let result: Result<(), ()> = wasi.call_run(&mut store).await?;
 
     if result.is_err() {
         anyhow::bail!("command returned with failing exit status");

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -54,19 +54,21 @@ async fn run_command(
 ) -> anyhow::Result<()> {
     command::add_to_linker(linker, |x| x)?;
 
+    let mut argv: Vec<&str> = vec!["wasm"];
+    argv.extend(args.iter().map(String::as_str));
+
     let mut store = Store::new(
         engine,
         WasiCtxBuilder::new()
             .inherit_stdio()
             .inherit_network()
+            .args(&argv)
             .build(),
     );
 
     let (wasi, _instance) = Command::instantiate_async(&mut store, component, linker).await?;
 
-    let mut main_args: Vec<&str> = vec!["wasm"];
-    main_args.extend(args.iter().map(String::as_str));
-    let result: Result<(), ()> = wasi.call_main(&mut store, &main_args).await?;
+    let result: Result<(), ()> = wasi.call_main(&mut store).await?;
 
     if result.is_err() {
         anyhow::bail!("command returned with failing exit status");
@@ -83,13 +85,18 @@ async fn run_proxy(
 ) -> anyhow::Result<()> {
     proxy::add_to_linker(linker, |x| x)?;
 
-    let mut store = Store::new(engine, WasiCtxBuilder::new().build());
+    let mut argv: Vec<&str> = vec!["wasm"];
+    argv.extend(args.iter().map(String::as_str));
+
+    let mut store = Store::new(
+        engine,
+        WasiCtxBuilder::new().inherit_stdio().args(&argv).build(),
+    );
 
     let (wasi, _instance) = Proxy::instantiate_async(&mut store, component, linker).await?;
 
     // TODO: do something
     let _ = wasi;
-    let _ = args;
     let result: Result<(), ()> = Ok(());
 
     if result.is_err() {

--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -57,7 +57,7 @@ async fn instantiate(path: &str) -> Result<(Store<WasiCtx>, Command)> {
 
 async fn run_hello_stdout(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
     store.data_mut().set_args(&["gussie", "sparky", "willa"]);
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -73,7 +73,7 @@ async fn run_panic(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
         "good",
         "yesterday",
     ]);
-    let r = wasi.call_main(&mut store).await;
+    let r = wasi.call_run(&mut store).await;
     assert!(r.is_err());
     println!("{:?}", r);
     Ok(())
@@ -83,7 +83,7 @@ async fn run_args(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
     store
         .data_mut()
         .set_args(&["hello", "this", "", "is an argument", "with 🚩 emoji"]);
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -111,7 +111,7 @@ async fn run_random(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
 
     store.data_mut().random = Box::new(FakeRng);
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -161,7 +161,7 @@ async fn run_time(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
     store.data_mut().clocks.instance_monotonic_clock =
         Box::new(FakeMonotonicClock { now: Mutex::new(0) });
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -173,7 +173,7 @@ async fn run_stdin(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
             "So rested he by the Tumtum tree",
         ))));
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -185,7 +185,7 @@ async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> 
             "So rested he by the Tumtum tree",
         ))));
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -193,7 +193,7 @@ async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> 
 async fn run_env(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
     store.data_mut().push_env("frabjous", "day");
     store.data_mut().push_env("callooh", "callay");
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -209,7 +209,7 @@ async fn run_file_read(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
         "/",
     )?;
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -226,7 +226,7 @@ async fn run_file_append(mut store: Store<WasiCtx>, wasi: Command) -> Result<()>
         "/",
     )?;
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))?;
 
@@ -253,13 +253,13 @@ async fn run_file_dir_sync(mut store: Store<WasiCtx>, wasi: Command) -> Result<(
         "/",
     )?;
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_exit_success(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    let r = wasi.call_main(&mut store).await;
+    let r = wasi.call_run(&mut store).await;
     let err = r.unwrap_err();
     let status = err.downcast_ref::<wasi_common::I32Exit>().unwrap();
     assert_eq!(status.0, 0);
@@ -267,13 +267,13 @@ async fn run_exit_success(mut store: Store<WasiCtx>, wasi: Command) -> Result<()
 }
 
 async fn run_exit_default(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    let r = wasi.call_main(&mut store).await?;
+    let r = wasi.call_run(&mut store).await?;
     assert!(r.is_ok());
     Ok(())
 }
 
 async fn run_exit_failure(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    let r = wasi.call_main(&mut store).await;
+    let r = wasi.call_run(&mut store).await;
     let err = r.unwrap_err();
     let status = err.downcast_ref::<wasi_common::I32Exit>().unwrap();
     assert_eq!(status.0, 1);
@@ -281,7 +281,7 @@ async fn run_exit_failure(mut store: Store<WasiCtx>, wasi: Command) -> Result<()
 }
 
 async fn run_exit_panic(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    let r = wasi.call_main(&mut store).await;
+    let r = wasi.call_run(&mut store).await;
     let err = r.unwrap_err();
     // The panic should trap.
     assert!(err.downcast_ref::<wasi_common::I32Exit>().is_none());
@@ -304,13 +304,13 @@ async fn run_directory_list(mut store: Store<WasiCtx>, wasi: Command) -> Result<
         "/",
     )?;
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_default_clocks(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -327,7 +327,7 @@ async fn run_with_temp_dir(mut store: Store<WasiCtx>, wasi: Command) -> Result<(
     )?;
     store.data_mut().set_args(&["program", "/foo"]);
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -541,7 +541,7 @@ async fn run_unlink_file_trailing_slashes(store: Store<WasiCtx>, wasi: Command) 
 }
 
 async fn run_export_cabi_realloc(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -560,7 +560,7 @@ async fn run_read_only(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
         "/",
     )?;
 
-    wasi.call_main(&mut store)
+    wasi.call_run(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))?;
 

--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -56,39 +56,36 @@ async fn instantiate(path: &str) -> Result<(Store<WasiCtx>, Command)> {
 }
 
 async fn run_hello_stdout(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    wasi.call_main(&mut store, &["gussie", "sparky", "willa"])
+    store.data_mut().set_args(&["gussie", "sparky", "willa"]);
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_panic(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    let r = wasi
-        .call_main(
-            &mut store,
-            &[
-                "diesel",
-                "the",
-                "cat",
-                "scratched",
-                "me",
-                "real",
-                "good",
-                "yesterday",
-            ],
-        )
-        .await;
+    store.data_mut().set_args(&[
+        "diesel",
+        "the",
+        "cat",
+        "scratched",
+        "me",
+        "real",
+        "good",
+        "yesterday",
+    ]);
+    let r = wasi.call_main(&mut store).await;
     assert!(r.is_err());
     println!("{:?}", r);
     Ok(())
 }
 
 async fn run_args(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    wasi.call_main(
-        &mut store,
-        &["hello", "this", "", "is an argument", "with 🚩 emoji"],
-    )
-    .await?
-    .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
+    store
+        .data_mut()
+        .set_args(&["hello", "this", "", "is an argument", "with 🚩 emoji"]);
+    wasi.call_main(&mut store)
+        .await?
+        .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_random(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
@@ -114,7 +111,7 @@ async fn run_random(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
 
     store.data_mut().random = Box::new(FakeRng);
 
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -164,7 +161,7 @@ async fn run_time(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
     store.data_mut().clocks.instance_monotonic_clock =
         Box::new(FakeMonotonicClock { now: Mutex::new(0) });
 
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -176,7 +173,7 @@ async fn run_stdin(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
             "So rested he by the Tumtum tree",
         ))));
 
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -188,7 +185,7 @@ async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> 
             "So rested he by the Tumtum tree",
         ))));
 
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -196,7 +193,7 @@ async fn run_poll_stdin(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> 
 async fn run_env(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
     store.data_mut().push_env("frabjous", "day");
     store.data_mut().push_env("callooh", "callay");
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -212,7 +209,7 @@ async fn run_file_read(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
         "/",
     )?;
 
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -229,7 +226,7 @@ async fn run_file_append(mut store: Store<WasiCtx>, wasi: Command) -> Result<()>
         "/",
     )?;
 
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))?;
 
@@ -256,13 +253,13 @@ async fn run_file_dir_sync(mut store: Store<WasiCtx>, wasi: Command) -> Result<(
         "/",
     )?;
 
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_exit_success(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    let r = wasi.call_main(&mut store, &[]).await;
+    let r = wasi.call_main(&mut store).await;
     let err = r.unwrap_err();
     let status = err.downcast_ref::<wasi_common::I32Exit>().unwrap();
     assert_eq!(status.0, 0);
@@ -270,13 +267,13 @@ async fn run_exit_success(mut store: Store<WasiCtx>, wasi: Command) -> Result<()
 }
 
 async fn run_exit_default(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    let r = wasi.call_main(&mut store, &[]).await?;
+    let r = wasi.call_main(&mut store).await?;
     assert!(r.is_ok());
     Ok(())
 }
 
 async fn run_exit_failure(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    let r = wasi.call_main(&mut store, &[]).await;
+    let r = wasi.call_main(&mut store).await;
     let err = r.unwrap_err();
     let status = err.downcast_ref::<wasi_common::I32Exit>().unwrap();
     assert_eq!(status.0, 1);
@@ -284,7 +281,7 @@ async fn run_exit_failure(mut store: Store<WasiCtx>, wasi: Command) -> Result<()
 }
 
 async fn run_exit_panic(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    let r = wasi.call_main(&mut store, &[]).await;
+    let r = wasi.call_main(&mut store).await;
     let err = r.unwrap_err();
     // The panic should trap.
     assert!(err.downcast_ref::<wasi_common::I32Exit>().is_none());
@@ -307,13 +304,13 @@ async fn run_directory_list(mut store: Store<WasiCtx>, wasi: Command) -> Result<
         "/",
     )?;
 
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
 
 async fn run_default_clocks(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -328,8 +325,9 @@ async fn run_with_temp_dir(mut store: Store<WasiCtx>, wasi: Command) -> Result<(
         Box::new(wasi_cap_std_sync::dir::Dir::from_cap_std(open_dir)),
         "/foo",
     )?;
+    store.data_mut().set_args(&["program", "/foo"]);
 
-    wasi.call_main(&mut store, &["program", "/foo"])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -543,7 +541,7 @@ async fn run_unlink_file_trailing_slashes(store: Store<WasiCtx>, wasi: Command) 
 }
 
 async fn run_export_cabi_realloc(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))
 }
@@ -562,7 +560,7 @@ async fn run_read_only(mut store: Store<WasiCtx>, wasi: Command) -> Result<()> {
         "/",
     )?;
 
-    wasi.call_main(&mut store, &[])
+    wasi.call_main(&mut store)
         .await?
         .map_err(|()| anyhow::anyhow!("command returned with failing exit status"))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub mod bindings {
         raw_strings,
         // The generated definition of command will pull in std, so we are defining it
         // manually below instead
-        skip: ["main", "get-directories", "get-environment"],
+        skip: ["run", "get-directories", "get-environment"],
     });
 
     #[cfg(feature = "reactor")]
@@ -46,7 +46,7 @@ pub mod bindings {
 
 #[no_mangle]
 #[cfg(feature = "command")]
-pub unsafe extern "C" fn main() -> u32 {
+pub unsafe extern "C" fn run() -> u32 {
     #[link(wasm_import_module = "__main_module__")]
     extern "C" {
         fn _start();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,12 +46,7 @@ pub mod bindings {
 
 #[no_mangle]
 #[cfg(feature = "command")]
-pub unsafe extern "C" fn main(args_ptr: *const WasmStr, args_len: usize) -> u32 {
-    State::with_mut(|state| {
-        state.args = Some(slice::from_raw_parts(args_ptr, args_len));
-        Ok(())
-    });
-
+pub unsafe extern "C" fn main() -> u32 {
     #[link(wasm_import_module = "__main_module__")]
     extern "C" {
         fn _start();
@@ -244,21 +239,19 @@ pub unsafe extern "C" fn cabi_export_realloc(
 #[no_mangle]
 pub unsafe extern "C" fn args_get(mut argv: *mut *mut u8, mut argv_buf: *mut u8) -> Errno {
     State::with(|state| {
-        if let Some(args) = state.args {
-            for arg in args {
-                // Copy the argument into `argv_buf` which must be sized
-                // appropriately by the caller.
-                ptr::copy_nonoverlapping(arg.ptr, argv_buf, arg.len);
-                *argv_buf.add(arg.len) = 0;
+        for arg in state.get_args() {
+            // Copy the argument into `argv_buf` which must be sized
+            // appropriately by the caller.
+            ptr::copy_nonoverlapping(arg.ptr, argv_buf, arg.len);
+            *argv_buf.add(arg.len) = 0;
 
-                // Copy the argument pointer into the `argv` buf
-                *argv = argv_buf;
+            // Copy the argument pointer into the `argv` buf
+            *argv = argv_buf;
 
-                // Update our pointers past what's written to prepare for the
-                // next argument.
-                argv = argv.add(1);
-                argv_buf = argv_buf.add(arg.len + 1);
-            }
+            // Update our pointers past what's written to prepare for the
+            // next argument.
+            argv = argv.add(1);
+            argv_buf = argv_buf.add(arg.len + 1);
         }
         Ok(())
     })
@@ -268,18 +261,11 @@ pub unsafe extern "C" fn args_get(mut argv: *mut *mut u8, mut argv_buf: *mut u8)
 #[no_mangle]
 pub unsafe extern "C" fn args_sizes_get(argc: *mut Size, argv_buf_size: *mut Size) -> Errno {
     State::with(|state| {
-        match state.args {
-            Some(args) => {
-                *argc = args.len();
-                // Add one to each length for the terminating nul byte added by
-                // the `args_get` function.
-                *argv_buf_size = args.iter().map(|s| s.len + 1).sum();
-            }
-            None => {
-                *argc = 0;
-                *argv_buf_size = 0;
-            }
-        }
+        let args = state.get_args();
+        *argc = args.len();
+        // Add one to each length for the terminating nul byte added by
+        // the `args_get` function.
+        *argv_buf_size = args.iter().map(|s| s.len + 1).sum();
         Ok(())
     })
 }
@@ -2087,8 +2073,9 @@ struct State {
     /// which need to be long-lived, by using `import_alloc.with_arena`.
     long_lived_arena: BumpArena,
 
-    /// Arguments passed to the `main` entrypoint
-    args: Option<&'static [WasmStr]>,
+    /// Arguments. Initialized lazily. Access with `State::get_args` to take care of
+    /// initialization.
+    args: Cell<Option<&'static [WasmStr]>>,
 
     /// Environment variables. Initialized lazily. Access with `State::get_environment`
     /// to take care of initialization.
@@ -2131,6 +2118,12 @@ impl Drop for DirectoryEntryStream {
 #[repr(C)]
 pub struct WasmStr {
     ptr: *const u8,
+    len: usize,
+}
+
+#[repr(C)]
+pub struct WasmStrList {
+    base: *const WasmStr,
     len: usize,
 }
 
@@ -2265,7 +2258,7 @@ impl State {
                 descriptors: RefCell::new(None),
                 path_buf: UnsafeCell::new(MaybeUninit::uninit()),
                 long_lived_arena: BumpArena::new(),
-                args: None,
+                args: Cell::new(None),
                 env_vars: Cell::new(None),
                 dirent_cache: DirentCache {
                     stream: Cell::new(None),
@@ -2363,5 +2356,29 @@ impl State {
             }));
         }
         self.env_vars.get().trapping_unwrap()
+    }
+
+    fn get_args(&self) -> &[WasmStr] {
+        if self.args.get().is_none() {
+            #[link(wasm_import_module = "environment")]
+            extern "C" {
+                #[link_name = "get-arguments"]
+                fn get_args_import(rval: *mut WasmStrList);
+            }
+            let mut list = WasmStrList {
+                base: std::ptr::null(),
+                len: 0,
+            };
+            self.import_alloc
+                .with_arena(&self.long_lived_arena, || unsafe {
+                    get_args_import(&mut list as *mut _)
+                });
+            self.args.set(Some(unsafe {
+                /* allocation comes from long lived arena, so it is safe to
+                 * cast this to a &'static slice: */
+                std::slice::from_raw_parts(list.base, list.len)
+            }));
+        }
+        self.args.get().trapping_unwrap()
     }
 }

--- a/wasi-common/cap-std-sync/src/lib.rs
+++ b/wasi-common/cap-std-sync/src/lib.rs
@@ -113,6 +113,10 @@ impl WasiCtxBuilder {
         self.0.insert_listener(fd, listener);
         self
     }
+    pub fn args(mut self, args: &[impl AsRef<str>]) -> Self {
+        self.0.set_args(args);
+        self
+    }
     pub fn build(self) -> WasiCtx {
         self.0
     }

--- a/wasi-common/src/ctx.rs
+++ b/wasi-common/src/ctx.rs
@@ -17,6 +17,7 @@ pub struct WasiCtx {
     pub sched: Box<dyn WasiSched>,
     pub table: Table,
     pub env: Vec<(String, String)>,
+    pub args: Vec<String>,
     pub preopens: Vec<(Box<dyn WasiDir>, String)>,
     pub pool: Pool,
     pub network_creator: Box<dyn Fn(Pool) -> Result<Box<dyn WasiNetwork>, Error> + Send + Sync>,
@@ -41,6 +42,7 @@ impl WasiCtx {
             sched,
             table,
             env: Vec::new(),
+            args: Vec::new(),
             preopens: Vec::new(),
             pool: Pool::new(),
             network_creator,
@@ -135,6 +137,17 @@ impl WasiCtx {
 
     pub fn push_env(&mut self, name: &str, value: &str) {
         self.env.push((name.to_owned(), value.to_owned()))
+    }
+
+    pub fn push_arg(&mut self, arg: &str) {
+        self.args.push(arg.to_owned())
+    }
+
+    pub fn set_args(&mut self, args: &[impl AsRef<str>]) {
+        self.args = args
+            .iter()
+            .map(|a| a.as_ref().to_string())
+            .collect::<Vec<String>>();
     }
 
     pub fn push_preopened_dir(&mut self, dir: Box<dyn WasiDir>, path: &str) -> anyhow::Result<()> {

--- a/wit/command.wit
+++ b/wit/command.wit
@@ -19,7 +19,5 @@ default world command {
   import preopens: pkg.preopens
   import exit: pkg.exit
 
-  export main: func(
-    args: list<string>,
-  ) -> result
+  export main: func() -> result
 }

--- a/wit/command.wit
+++ b/wit/command.wit
@@ -19,5 +19,5 @@ default world command {
   import preopens: pkg.preopens
   import exit: pkg.exit
 
-  export main: func() -> result
+  export run: func() -> result
 }

--- a/wit/environment.wit
+++ b/wit/environment.wit
@@ -8,4 +8,7 @@ default interface environment {
   /// in the component model, this import function should return the same
   /// values each time it is called.
   get-environment: func() -> list<tuple<string, string>>
+
+  /// Get the POSIX-style arguments to the program.
+  get-arguments: func() -> list<string>
 }


### PR DESCRIPTION
This is a follow-on to #123.

Following the principle of wit-ifying preview 1 as faithfully as possible, we are making args available by calling an import function `environment::get-arguments: func() -> list<string>` rather than by passing them to the command's export func `main`.

Implementation in the adapter follows the pattern used for environment variables: arguments are fetched lazily, using the long-lived allocation pool.

This work ended up hitting a rust or wasm-ld behavior/bug which meant I had to (hopefully, temporarily) rename command's `main` to `run`. When the adapter's `main` was modified to take no parameters, something in the toolchain is detecting a special case and renaming it to `__original_main`, and exporting a `main` that takes two i32 parameters. This type signature is incompatible with the canonical abi, so I had to somehow get around this behavior. Naming the export func `run` seemed relatively unobjectionable, and lets us move forward while we figure out how to fix the toolchain.