### PR TITLE
add `trappable_error_type` for `streams::stream-error`

### DIFF
--- a/host/src/command.rs
+++ b/host/src/command.rs
@@ -6,7 +6,10 @@ pub mod wasi {
         world: "command",
         tracing: true,
         async: true,
-        trappable_error_type: { "filesystem"::"error-code": Error }
+        trappable_error_type: {
+            "filesystem"::"error-code": Error,
+            "streams"::"stream-error": Error,
+        }
     });
 }
 

--- a/host/src/proxy.rs
+++ b/host/src/proxy.rs
@@ -6,6 +6,10 @@ pub mod wasi {
         world: "proxy",
         tracing: true,
         async: true,
+        trappable_error_type: {
+            "filesystem"::"error-code": Error,
+            "streams"::"stream-error": Error,
+        }
     });
 }
 

--- a/test-programs/src/bin/read_only.rs
+++ b/test-programs/src/bin/read_only.rs
@@ -19,10 +19,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         assert_eq!("while in thought", &io::read_to_string(&mut file)?);
 
-        // TODO: this currently traps instead of returning an error:
-        // assert!(file
-        //     .write_all(b"Did gyre and gimble in the wabe;\n")
-        //     .is_err());
+        assert!(file
+            .write_all(b"Did gyre and gimble in the wabe;\n")
+            .is_err());
     }
 
     assert!(OpenOptions::new().append(true).open("bar.txt").is_err());


### PR DESCRIPTION
This allows us to easily pass errors to the guest instead of trapping.