### PR TITLE
Fix wasi renumber test

### DIFF
--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -493,7 +493,7 @@ async fn run_remove_nonempty_directory(store: Store<WasiCtx>, wasi: Command) -> 
 }
 
 async fn run_renumber(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    expect_fail(run_with_temp_dir(store, wasi).await)
+    run_with_temp_dir(store, wasi).await
 }
 
 async fn run_sched_yield(store: Store<WasiCtx>, wasi: Command) -> Result<()> {

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -258,6 +258,11 @@ impl Descriptors {
 
     // Internal: close a fd, returning the descriptor.
     fn close_(&mut self, fd: Fd) -> Result<Descriptor, Errno> {
+        // Throw an error if closing an fd which is already closed
+        match self.get_mut(fd)? {
+            Descriptor::Closed(_) => Err(wasi::ERRNO_BADF)?,
+            _ => {}
+        }
         // Mutate the descriptor to be closed, and push the closed fd onto the head of the linked list:
         let last_closed = self.closed;
         let prev = std::mem::replace(self.get_mut(fd)?, Descriptor::Closed(last_closed));


### PR DESCRIPTION
In the adapter, return ERRNO_BADF if trying to close an already closed file. This is the preview 1 behavior, and makes the renumber test pass.