### PR TITLE
fix fd_filestat_get: adapter special-case StreamType::Unknown

### DIFF
--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -361,7 +361,7 @@ async fn run_fd_advise(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
 }
 
 async fn run_fd_filestat_get(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    expect_fail(run_with_temp_dir(store, wasi).await)
+    run_with_temp_dir(store, wasi).await
 }
 
 async fn run_fd_filestat_set(store: Store<WasiCtx>, wasi: Command) -> Result<()> {


### PR DESCRIPTION
giving an empty Filestat, instead of returning an error.

This implements the behavior expected by the fd_filestat_get test.

We might end up being able to rename StreamType's Unknown variant to Stdio, since it looks like that is the only place we construct it. However, I will leave that to future work.