### PR TITLE
Fix support for tracing, add --mapdir to host cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,23 +356,22 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862eb053fc21f991db27c73bc51494fe77aadfa09ea257cb43b62a2656fd4cc1"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038a74bc85da2f6f9e237c51b7998b47229c0f9da69b4c6b0590cf6621c45d46"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
+ "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
@@ -379,33 +384,37 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb720a7955cf7cc92c58f3896952589062e6f12d8eb35ef4337e708ed2e738"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0954f9426cf0fa7ad57910ea5822a09c5da590222a767a6c38080a8534a0af8"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
+
+[[package]]
+name = "cranelift-control"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
+dependencies = [
+ "arbitrary",
+]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c7096c1a66cfa73899645f0a46a6f5c91641e678eeafb0fc47a19ab34069ca"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697f2fdaceb228fea413ea91baa7c6b8533fc2e61ac5a08db7acc1b31e673a2a"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -415,15 +424,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41037f4863e0c6716dbe60e551d501f4197383cb43d75038c0170159fc8fb5b"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 
 [[package]]
 name = "cranelift-native"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797c6e5643eb654bb7bf496f1f03518323a89b937b84020b786620f910364a52"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -432,9 +439,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.94.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b5fae12cefda3a2c43837e562dd525ab1d75b27989eece66de5b2c8fe120f9"
+version = "0.96.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -442,7 +448,7 @@ dependencies = [
  "itertools",
  "log",
  "smallvec",
- "wasmparser 0.100.0",
+ "wasmparser 0.102.0",
  "wasmtime-types",
 ]
 
@@ -1713,17 +1719,8 @@ dependencies = [
  "byte-array",
  "object",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-encoder 0.25.0",
+ "wasm-encoder",
  "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3e4bc09095436c8e7584d86d33e6c3ee67045af8fb262cbb9cc321de553428"
-dependencies = [
- "leb128",
 ]
 
 [[package]]
@@ -1744,7 +1741,7 @@ dependencies = [
  "anyhow",
  "indexmap",
  "serde",
- "wasm-encoder 0.25.0",
+ "wasm-encoder",
  "wasmparser 0.102.0",
 ]
 
@@ -1755,16 +1752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da34cec2a8c23db906cdf8b26e988d7a7f0d549eb5d51299129647af61a1b37"
 dependencies = [
  "indexmap",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.100.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
-dependencies = [
- "indexmap",
- "url",
 ]
 
 [[package]]
@@ -1789,9 +1776,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d137f87df6e037b2bcb960c2db7ea174e04fb897051380c14b5e5475a870669e"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1808,7 +1794,7 @@ dependencies = [
  "rayon",
  "serde",
  "target-lexicon",
- "wasmparser 0.100.0",
+ "wasmparser 0.102.0",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -1817,24 +1803,23 @@ dependencies = [
  "wasmtime-fiber",
  "wasmtime-jit",
  "wasmtime-runtime",
+ "wasmtime-winch",
  "wat",
  "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad63d4175d6af44af2046186c87deae4e9a8150b92de2d4809c6f745d5ee9b38"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3055fb327f795b4639f47b9dadad9d3d9b185fd3001adf8db08f5fa06d07032"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "anyhow",
  "base64",
@@ -1852,9 +1837,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cf4906f990d6ab3065d042cf5a15eb7a2a5406d1c001a45ab9615de876458a"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1867,18 +1851,17 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ccf49c18c1ce3f682310e642dcdc00ffc67f1ce0767c89a16fc8fcf5eaeb97"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274590ecbb1179d45a5c8d9f54b9d236e9414d9ca3b861cd8956cec085508eb0"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
+ "cranelift-control",
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
@@ -1888,15 +1871,30 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.100.0",
+ "wasmparser 0.102.0",
+ "wasmtime-cranelift-shared",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-cranelift-shared"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-native",
+ "gimli",
+ "object",
+ "target-lexicon",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b4a897e6ce1f2567ba98e7b1948c0e12cae1202fd88e7639f901b8ce9203f7"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -1907,8 +1905,8 @@ dependencies = [
  "serde",
  "target-lexicon",
  "thiserror",
- "wasm-encoder 0.23.0",
- "wasmparser 0.100.0",
+ "wasm-encoder",
+ "wasmparser 0.102.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -1916,9 +1914,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b1192624694399f601de28db78975ed20fa859da8e048bf8250bd3b38d302b"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1929,9 +1926,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f035bfe27ce5129c9d081d6288480f2e6ae9d16d0eb035a5d9e3b5b6c36658"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1954,9 +1950,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e35d335dd2461c631ba24d2326d993bd3a4bdb4b0217e5bda4f518ba0e29f3"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "object",
  "once_cell",
@@ -1965,9 +1960,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8c01a070f55343f7afd309a9609c12378548b26c3f53c599bc711bb1ce42ee"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1976,9 +1970,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac02cc14c8247f6e4e48c7653a79c226babac8f2cacdd933d3f15ca2a6ab20b"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "anyhow",
  "cc",
@@ -2002,21 +1995,36 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dc0062ab053e1aa22d2355a2de4df482a0007fecae82ea02cc596c2329971d"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.100.0",
+ "wasmparser 0.102.0",
+]
+
+[[package]]
+name = "wasmtime-winch"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.102.0",
+ "wasmtime-cranelift-shared",
+ "wasmtime-environ",
+ "winch-codegen",
+ "winch-environ",
 ]
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd2cf93f3c8a6f443d8a9098fddc5fd887783c0fe725dc10c54ca9280546421d"
+version = "9.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
 dependencies = [
  "anyhow",
  "heck",
@@ -2032,7 +2040,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.25.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -2074,6 +2082,30 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "0.7.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser 0.102.0",
+]
+
+[[package]]
+name = "winch-environ"
+version = "0.7.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=cc1c14ac913be13329e5cfc91c33e053ab722132#cc1c14ac913be13329e5cfc91c33e053ab722132"
+dependencies = [
+ "wasmparser 0.102.0",
+ "wasmtime-environ",
+ "winch-codegen",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2287,7 +2319,7 @@ dependencies = [
  "indexmap",
  "log",
  "url",
- "wasm-encoder 0.25.0",
+ "wasm-encoder",
  "wasm-metadata",
  "wasmparser 0.102.0",
  "wit-parser",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -16,9 +16,9 @@ wasmtime = { version = "7.0.0", features = ["component-model"] }
 wasi-common = { path = "../wasi-common" }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
 clap = { version = "4.1.9", features = ["derive"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt" ]}
 
 [dev-dependencies]
 test-programs-macros = { path = "../test-programs/macros" }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt" ]}
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tempfile = "3.3.0"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -12,7 +12,7 @@ cap-rand = { workspace = true }
 cap-net-ext = { workspace = true }
 tokio = { version = "1.22.0", features = [ "rt", "macros" ] }
 tracing = { workspace = true }
-wasmtime = { version = "7.0.0", features = ["component-model"] }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "cc1c14ac913be13329e5cfc91c33e053ab722132", features = ["component-model"] }
 wasi-common = { path = "../wasi-common" }
 wasi-cap-std-sync = { path = "../wasi-common/cap-std-sync" }
 clap = { version = "4.1.9", features = ["derive"] }

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use host::{command, command::wasi::Command, proxy, proxy::wasi::Proxy, WasiCtx};
 use wasi_cap_std_sync::WasiCtxBuilder;
 use wasmtime::{
@@ -71,7 +71,9 @@ async fn main() -> Result<()> {
         .args(&argv);
 
     for (guest, host) in args.map_dirs {
-        builder = builder.preopened_dir(dir, guest)?;
+        let dir = cap_std::fs::Dir::open_ambient_dir(&host, cap_std::ambient_authority())
+            .context(format!("opening directory {host:?}"))?;
+        builder = builder.preopened_dir(dir, &guest)?;
     }
 
     let wasi_ctx = builder.build();

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -21,10 +21,35 @@ struct Args {
     /// Name of the world to load it in.
     #[arg(long, default_value_t = String::from("command"))]
     world: String,
+
+    #[arg(
+        long = "mapdir",
+        number_of_values = 1,
+        value_name = "GUEST_DIR::HOST_DIR",
+        value_parser = parse_map_dir
+    )]
+    map_dirs: Vec<(String, String)>,
+}
+
+fn parse_map_dir(s: &str) -> Result<(String, String)> {
+    let parts: Vec<&str> = s.split("::").collect();
+    if parts.len() != 2 {
+        anyhow::bail!(
+            "failed parsing map dir: must contain exactly one double colon `::`, got {s:?}"
+        )
+    }
+    Ok((parts[0].to_string(), parts[1].to_string()))
 }
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
+
     let args = Args::parse();
     let input = args.component;
 
@@ -37,10 +62,24 @@ async fn main() -> Result<()> {
     let component = Component::from_file(&engine, &input)?;
     let mut linker = Linker::new(&engine);
 
+    let mut argv: Vec<&str> = vec!["wasm"];
+    argv.extend(args.args.iter().map(String::as_str));
+
+    let mut builder = WasiCtxBuilder::new()
+        .inherit_stdio()
+        .inherit_network()
+        .args(&argv);
+
+    for (guest, host) in args.map_dirs {
+        builder = builder.preopened_dir(dir, guest)?;
+    }
+
+    let wasi_ctx = builder.build();
+
     if args.world == "command" {
-        run_command(&mut linker, &engine, &component, &args.args).await?;
+        run_command(&mut linker, &engine, &component, wasi_ctx).await?;
     } else if args.world == "proxy" {
-        run_proxy(&mut linker, &engine, &component, &args.args).await?;
+        run_proxy(&mut linker, &engine, &component, wasi_ctx).await?;
     }
 
     Ok(())
@@ -50,21 +89,10 @@ async fn run_command(
     linker: &mut Linker<WasiCtx>,
     engine: &Engine,
     component: &Component,
-    args: &[String],
+    wasi_ctx: WasiCtx,
 ) -> anyhow::Result<()> {
     command::add_to_linker(linker, |x| x)?;
-
-    let mut argv: Vec<&str> = vec!["wasm"];
-    argv.extend(args.iter().map(String::as_str));
-
-    let mut store = Store::new(
-        engine,
-        WasiCtxBuilder::new()
-            .inherit_stdio()
-            .inherit_network()
-            .args(&argv)
-            .build(),
-    );
+    let mut store = Store::new(engine, wasi_ctx);
 
     let (wasi, _instance) = Command::instantiate_async(&mut store, component, linker).await?;
 
@@ -81,17 +109,11 @@ async fn run_proxy(
     linker: &mut Linker<WasiCtx>,
     engine: &Engine,
     component: &Component,
-    args: &[String],
+    wasi_ctx: WasiCtx,
 ) -> anyhow::Result<()> {
     proxy::add_to_linker(linker, |x| x)?;
 
-    let mut argv: Vec<&str> = vec!["wasm"];
-    argv.extend(args.iter().map(String::as_str));
-
-    let mut store = Store::new(
-        engine,
-        WasiCtxBuilder::new().inherit_stdio().args(&argv).build(),
-    );
+    let mut store = Store::new(engine, wasi_ctx);
 
     let (wasi, _instance) = Proxy::instantiate_async(&mut store, component, linker).await?;
 

--- a/wasi-common/cap-std-sync/src/lib.rs
+++ b/wasi-common/cap-std-sync/src/lib.rs
@@ -102,10 +102,14 @@ impl WasiCtxBuilder {
             .insert_ip_net_port_any(IpNet::new(Ipv6Addr::UNSPECIFIED.into(), 0).unwrap());
         self
     }
-    pub fn preopened_dir(mut self, fd: u32, dir: Dir) -> Self {
+    pub fn preopened_dir(
+        mut self,
+        dir: cap_std::fs::Dir,
+        guest_path: &str,
+    ) -> Result<Self, anyhow::Error> {
         let dir = Box::new(crate::dir::Dir::from_cap_std(dir));
-        self.0.insert_dir(fd, dir);
-        self
+        self.0.push_preopened_dir(dir, guest_path)?;
+        Ok(self)
     }
     pub fn preopened_listener(mut self, fd: u32, listener: impl Into<TcpSocket>) -> Self {
         let listener: TcpSocket = listener.into();


### PR DESCRIPTION
Use the latest wasmtime, which needed the following to make the `tracing: true` feature in wasmtime-wit-bindgen actually emit something useful: https://github.com/bytecodealliance/wasmtime/pull/6209

Install the tracing_subscriber in host's main.rs, so that RUST_LOG=host=trace works from the cli. (It already worked in tests, via test_log.)

And finally, implement `--mapdir` as a command line flag, stolen out of the wasmtime cli. I had to rejigger how preopens are constructed slightly to make this work out.

Sample output:
<details>
<pre>
[phickey@pch-tower:src/preview2-prototyping]% RUST_LOG=host=trace cargo run -p host -- read_empty_filename.component.wasm --mapdir /::tmp
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/host read_empty_filename.component.wasm --mapdir '/::tmp'`
2023-04-14T15:22:21.371311Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="preopens" function="get-stdio"}: host::command::wasi::preopens: call
2023-04-14T15:22:21.371359Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="preopens" function="get-stdio"}: host::command::wasi::preopens: return result=Ok(StdioPreopens { stdin: 0, stdout: 1, stderr: 2 })
2023-04-14T15:22:21.371451Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="preopens" function="get-directories"}: host::command::wasi::preopens: call
2023-04-14T15:22:21.371485Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="preopens" function="get-directories"}: host::command::wasi::preopens: return result=Ok([(3, "/")])
2023-04-14T15:22:21.371620Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="filesystem" function="open-at"}: host::command::wasi::filesystem: call this=3 path_flags=(SYMLINK_FOLLOW) path="." open_flags=() flags=(READ) modes=(READABLE|WRITEABLE)
2023-04-14T15:22:21.371687Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="filesystem" function="open-at"}: host::command::wasi::filesystem: return result=Ok(4)
2023-04-14T15:22:21.371766Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="filesystem" function="stat"}: host::command::wasi::filesystem: call this=4
2023-04-14T15:22:21.371806Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="filesystem" function="stat"}: host::command::wasi::filesystem: return result=Ok(DescriptorStat { device: 64769, inode: 17304241, type: DescriptorType::Directory, link-count: 2, size: 4096, data-access-timestamp: Datetime { seconds: 1681484998, nanoseconds: 564963481 }, data-modification-timestamp: Datetime { seconds: 1681348594, nanoseconds: 577238733 }, status-change-timestamp: Datetime { seconds: 1681348594, nanoseconds: 577238733 } })
2023-04-14T15:22:21.371896Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="filesystem" function="read-via-stream"}: host::command::wasi::filesystem: call this=4 offset=0
2023-04-14T15:22:21.371926Z TRACE wit-bindgen export{module="default" function="main"}:wit-bindgen import{module="filesystem" function="read-via-stream"}: host::command::wasi::filesystem: return result=Ok(5)
</pre>
</details>