### PR TITLE
deprecate fd_allocate

### DIFF
--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -357,7 +357,7 @@ async fn run_directory_seek(store: Store<WasiCtx>, wasi: Command) -> Result<()> 
 }
 
 async fn run_fd_advise(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    expect_fail(run_with_temp_dir(store, wasi).await)
+    run_with_temp_dir(store, wasi).await
 }
 
 async fn run_fd_filestat_get(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
@@ -377,7 +377,7 @@ async fn run_fd_readdir(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
 }
 
 async fn run_file_allocate(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    expect_fail(run_with_temp_dir(store, wasi).await)
+    run_with_temp_dir(store, wasi).await
 }
 
 async fn run_file_pread_pwrite(store: Store<WasiCtx>, wasi: Command) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -407,8 +407,10 @@ pub unsafe extern "C" fn fd_advise(
 pub unsafe extern "C" fn fd_allocate(fd: Fd, offset: Filesize, len: Filesize) -> Errno {
     State::with(|state| {
         let ds = state.descriptors();
+        // For not-files, fail with BADF
         let file = ds.get_file(fd)?;
-        unreachable!("fd_allocate is unimplemented")
+        // For all files, fail with NOTSUP, because this call does not exist in preview 2.
+        Err(wasi::ERRNO_NOTSUP)
     })
 }
 

--- a/test-programs/wasi-tests/src/bin/fd_advise.rs
+++ b/test-programs/wasi-tests/src/bin/fd_advise.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{open_scratch_directory, TESTCONFIG};
+use wasi_tests::open_scratch_directory;
 
 unsafe fn test_fd_advise(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory.
@@ -39,14 +39,6 @@ unsafe fn test_fd_advise(dir_fd: wasi::Fd) {
     // Advise shouldnt change size
     let stat = wasi::fd_filestat_get(file_fd).expect("failed to fdstat 3");
     assert_eq!(stat.size, 100, "file size should be 100");
-
-    if TESTCONFIG.support_fd_allocate() {
-        // Use fd_allocate to expand size to 200:
-        wasi::fd_allocate(file_fd, 100, 100).expect("allocating size");
-
-        let stat = wasi::fd_filestat_get(file_fd).expect("failed to fdstat 3");
-        assert_eq!(stat.size, 200, "file size should be 200");
-    }
 
     wasi::fd_close(file_fd).expect("failed to close");
     wasi::path_unlink_file(dir_fd, "file").expect("failed to unlink");

--- a/test-programs/wasi-tests/src/bin/file_allocate.rs
+++ b/test-programs/wasi-tests/src/bin/file_allocate.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{open_scratch_directory, TESTCONFIG};
+use wasi_tests::open_scratch_directory;
 
 unsafe fn test_file_allocate(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory.
@@ -25,22 +25,19 @@ unsafe fn test_file_allocate(dir_fd: wasi::Fd) {
     let mut stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
     assert_eq!(stat.size, 0, "file size should be 0");
 
-    if TESTCONFIG.support_fd_allocate() {
-        // Allocate some size
-        wasi::fd_allocate(file_fd, 0, 100).expect("allocating size");
-        stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
-        assert_eq!(stat.size, 100, "file size should be 100");
+    // Allocate some size
+    let err = wasi::fd_allocate(file_fd, 0, 100)
+        .err()
+        .expect("fd_allocate must fail");
+    assert_eq!(
+        err,
+        wasi::ERRNO_NOTSUP,
+        "fd_allocate should fail with NOTSUP"
+    );
 
-        // Allocate should not modify if less than current size
-        wasi::fd_allocate(file_fd, 10, 10).expect("allocating size less than current size");
-        stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
-        assert_eq!(stat.size, 100, "file size should remain unchanged at 100");
+    stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
+    assert_eq!(stat.size, 0, "file size should still be 0");
 
-        // Allocate should modify if offset+len > current_len
-        wasi::fd_allocate(file_fd, 90, 20).expect("allocating size larger than current size");
-        stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
-        assert_eq!(stat.size, 110, "file size should increase from 100 to 110");
-    }
     wasi::fd_close(file_fd).expect("closing a file");
     wasi::path_unlink_file(dir_fd, "file").expect("removing a file");
 }

--- a/test-programs/wasi-tests/src/config.rs
+++ b/test-programs/wasi-tests/src/config.rs
@@ -1,7 +1,6 @@
 pub struct TestConfig {
     errno_mode: ErrnoMode,
     no_dangling_filesystem: bool,
-    no_fd_allocate: bool,
     no_rename_dir_to_empty_dir: bool,
     no_fdflags_sync_support: bool,
     no_rights_readback_support: bool,
@@ -26,7 +25,6 @@ impl TestConfig {
             ErrnoMode::Permissive
         };
         let no_dangling_filesystem = std::env::var("NO_DANGLING_FILESYSTEM").is_ok();
-        let no_fd_allocate = std::env::var("NO_FD_ALLOCATE").is_ok();
         let no_rename_dir_to_empty_dir = std::env::var("NO_RENAME_DIR_TO_EMPTY_DIR").is_ok();
         let no_fdflags_sync_support = std::env::var("NO_FDFLAGS_SYNC_SUPPORT").is_ok();
         // Current support for rights readback is buggy, lets ignore that in tests and get
@@ -35,7 +33,6 @@ impl TestConfig {
         TestConfig {
             errno_mode,
             no_dangling_filesystem,
-            no_fd_allocate,
             no_rename_dir_to_empty_dir,
             no_fdflags_sync_support,
             no_rights_readback_support,
@@ -61,9 +58,6 @@ impl TestConfig {
     }
     pub fn support_dangling_filesystem(&self) -> bool {
         !self.no_dangling_filesystem
-    }
-    pub fn support_fd_allocate(&self) -> bool {
-        !self.no_fd_allocate
     }
     pub fn support_rename_dir_to_empty_dir(&self) -> bool {
         !self.no_rename_dir_to_empty_dir


### PR DESCRIPTION
Adapter always fails with NOTSUP for fd_allocate on files.

Changes to tests are upstream: https://github.com/bytecodealliance/wasmtime/pull/6217

This gets the `file_allocate` and `fd_advise` tests passing.