### PR TITLE
Fix readlink behavior

### DIFF
--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -481,7 +481,7 @@ async fn run_poll_oneoff_stdio(store: Store<WasiCtx>, wasi: Command) -> Result<(
 }
 
 async fn run_readlink(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    expect_fail(run_with_temp_dir(store, wasi).await)
+    run_with_temp_dir(store, wasi).await
 }
 
 async fn run_remove_directory_trailing_slashes(store: Store<WasiCtx>, wasi: Command) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1399,12 +1399,14 @@ pub unsafe extern "C" fn path_readlink(
                 .with_buffer(buf, buf_len, || filesystem::readlink_at(file.fd, path))?
         };
 
-        *bufused = path.len();
         if use_state_buf {
             // Preview1 follows POSIX in truncating the returned path if it
             // doesn't fit.
             let len = min(path.len(), buf_len);
             ptr::copy_nonoverlapping(path.as_ptr().cast(), buf, len);
+            *bufused = len;
+        } else {
+            *bufused = path.len();
         }
 
         // The returned string's memory was allocated in `buf`, so don't separately

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1399,9 +1399,6 @@ pub unsafe extern "C" fn path_readlink(
                 .with_buffer(buf, buf_len, || filesystem::readlink_at(file.fd, path))?
         };
 
-        assert_eq!(path.as_ptr(), buf);
-        assert!(path.len() <= buf_len);
-
         *bufused = path.len();
         if use_state_buf {
             // Preview1 follows POSIX in truncating the returned path if it

--- a/test-programs/wasi-tests/src/bin/readlink.rs
+++ b/test-programs/wasi-tests/src/bin/readlink.rs
@@ -22,10 +22,10 @@ unsafe fn test_readlink(dir_fd: wasi::Fd) {
 
     // Read link into smaller buffer than the actual link's length
     let buf = &mut [0u8; 4];
-    let err = wasi::path_readlink(dir_fd, "symlink", buf.as_mut_ptr(), buf.len())
-        .err()
-        .expect("readlink with too-small buffer should fail");
-    assert_errno!(err, wasi::ERRNO_RANGE);
+    let bufused = wasi::path_readlink(dir_fd, "symlink", buf.as_mut_ptr(), buf.len())
+        .expect("readlink with too-small buffer should silently truncate");
+    assert_eq!(bufused, 4);
+    assert_eq!(buf, b"targ");
 
     // Clean up.
     wasi::path_unlink_file(dir_fd, "target").expect("removing a file");


### PR DESCRIPTION
* Adapter had an incorrect assertion
* Adapter returned wrong len in the case of truncation
* Test now expects truncation behavior
* Test and truncation behavior changes backported to wasmtime https://github.com/bytecodealliance/wasmtime/pull/6225