### PR TITLE
Add a WASI test for creating an absolute-path symlink

### DIFF
--- a/test-programs/wasi-tests/src/bin/symlink_create.rs
+++ b/test-programs/wasi-tests/src/bin/symlink_create.rs
@@ -62,6 +62,11 @@ unsafe fn create_symlink_to_directory(dir_fd: wasi::Fd) {
         .expect("remove_directory on a directory should succeed");
 }
 
+unsafe fn create_symlink_to_root(dir_fd: wasi::Fd) {
+    // Create a symlink.
+    wasi::path_symlink("/", dir_fd, "symlink").expect_err("creating a symlink to an absolute path");
+}
+
 fn main() {
     let mut args = env::args();
     let prog = args.next().unwrap();
@@ -85,5 +90,6 @@ fn main() {
     unsafe {
         create_symlink_to_file(dir_fd);
         create_symlink_to_directory(dir_fd);
+        create_symlink_to_root(dir_fd);
     }
 }


### PR DESCRIPTION
Wasmtime disallows guests from using path_symlink to create absolute-path symlinks, as they could confuse other code into accessing resources on the host that the guest otherwise doesn't have access to.

This patch adds a test for this behavior.

Authored by @sunfishcode in https://github.com/bytecodealliance/wasmtime/pull/6071