### PR TITLE
Eliminate nonblocking from descriptor flags

### DIFF
--- a/host/src/filesystem.rs
+++ b/host/src/filesystem.rs
@@ -101,9 +101,6 @@ impl From<FdFlags> for wasi::filesystem::DescriptorFlags {
         if fdflags.contains(FdFlags::DSYNC) {
             flags |= wasi::filesystem::DescriptorFlags::DATA_INTEGRITY_SYNC;
         }
-        if fdflags.contains(FdFlags::NONBLOCK) {
-            flags |= wasi::filesystem::DescriptorFlags::NON_BLOCKING;
-        }
         if fdflags.contains(FdFlags::RSYNC) {
             flags |= wasi::filesystem::DescriptorFlags::REQUESTED_WRITE_SYNC;
         }
@@ -119,9 +116,6 @@ impl From<wasi::filesystem::DescriptorFlags> for FdFlags {
         let mut fdflags = FdFlags::empty();
         if flags.contains(wasi::filesystem::DescriptorFlags::DATA_INTEGRITY_SYNC) {
             fdflags |= FdFlags::DSYNC;
-        }
-        if flags.contains(wasi::filesystem::DescriptorFlags::NON_BLOCKING) {
-            fdflags |= FdFlags::NONBLOCK;
         }
         if flags.contains(wasi::filesystem::DescriptorFlags::REQUESTED_WRITE_SYNC) {
             fdflags |= FdFlags::RSYNC;
@@ -259,15 +253,6 @@ impl wasi::filesystem::Host for WasiCtx {
         } else {
             Err(wasi::filesystem::ErrorCode::BadDescriptor.into())
         }
-    }
-
-    async fn set_flags(
-        &mut self,
-        fd: wasi::filesystem::Descriptor,
-        flags: wasi::filesystem::DescriptorFlags,
-    ) -> Result<(), wasi::filesystem::Error> {
-        // FIXME
-        Err(wasi::filesystem::ErrorCode::Unsupported.into())
     }
 
     async fn set_size(

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -191,6 +191,7 @@ impl Descriptors {
                         .trapping_unwrap(),
                     position: Cell::new(0),
                     append: false,
+                    blocking: false,
                 }),
             }))
             .trapping_unwrap();

--- a/test-programs/wasi-tests/src/bin/readlink.rs
+++ b/test-programs/wasi-tests/src/bin/readlink.rs
@@ -1,5 +1,5 @@
 use std::{env, process};
-use wasi_tests::{assert_errno, create_file, open_scratch_directory};
+use wasi_tests::{create_file, open_scratch_directory};
 
 unsafe fn test_readlink(dir_fd: wasi::Fd) {
     // Create a file in the scratch directory.

--- a/wit/deps/filesystem/filesystem.wit
+++ b/wit/deps/filesystem/filesystem.wit
@@ -55,14 +55,6 @@ default interface filesystem {
         read,
         /// Write mode: Data can be written to.
         write,
-        /// Requests non-blocking operation.
-        ///
-        /// When this flag is enabled, functions may return immediately with an
-        /// `error-code::would-block` error code in situations where they would
-        /// otherwise block. However, this non-blocking behavior is not
-        /// required. Implementations are permitted to ignore this flag and
-        /// block. This is similar to `O_NONBLOCK` in POSIX.
-        non-blocking,
         /// Request that writes be performed according to synchronized I/O file
         /// integrity completion. The data stored in the file and the file's
         /// metadata are synchronized. This is similar to `O_SYNC` in POSIX.
@@ -373,15 +365,6 @@ default interface filesystem {
     /// Note: This returns the value that was the `fs_filetype` value returned
     /// from `fdstat_get` in earlier versions of WASI.
     get-type: func(this: descriptor) -> result<descriptor-type, error-code>
-
-    /// Set status flags associated with a descriptor.
-    ///
-    /// This function may only change the `non-blocking` flag.
-    ///
-    /// Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
-    ///
-    /// Note: This was called `fd_fdstat_set_flags` in earlier versions of WASI.
-    set-flags: func(this: descriptor, %flags: descriptor-flags) -> result<_, error-code>
 
     /// Adjust the size of an open file. If this increases the file's size, the
     /// extra bytes are filled with zeros.


### PR DESCRIPTION
In Preview 2, streams have a pair of blocking and non-blocking methods for reading or writing. Therefore, being blocking or not is no longer a property of the file descriptor, and has been removed from the descriptor-flags. And, as a follow-on, the `set-flags` method was only for changing the nonblocking flag (target operating systems do not support changing any of the other descriptor-flags), so we can drop that method entirely.

For adapting Preview 1, we can store whether a fd is blocking or not as a boolean field in the `File` struct, and still treat it as a preview 1 fdflag. The blocking field in `File` is used to determine whether `fd_read` dispatches to `streams::read` or `streams::blocking_read`. non-Files default to `streams::read`.

The host side of this is not fully implemented: we are not actually opening all files as nonblocking under the hood, and then polling them for readiness before a (blocking) stream read/write call. That change requires some more extensive renovation to the way the host-side polling and traits are designed, so I'm going to land this first and work on that later.