### PR TITLE
Fixes for seek/append behavior

### DIFF
--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -374,8 +374,7 @@ async fn run_fd_filestat_set(store: Store<WasiCtx>, wasi: Command) -> Result<()>
 }
 
 async fn run_fd_flags_set(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    // dies with notsup: line 95
-    expect_fail(run_with_temp_dir(store, wasi).await)
+    run_with_temp_dir(store, wasi).await
 }
 
 async fn run_fd_readdir(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
@@ -391,7 +390,6 @@ async fn run_file_pread_pwrite(store: Store<WasiCtx>, wasi: Command) -> Result<(
 }
 
 async fn run_file_seek_tell(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    // dies when expected error doesnt happen: line 60
     run_with_temp_dir(store, wasi).await
 }
 

--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -392,7 +392,7 @@ async fn run_file_pread_pwrite(store: Store<WasiCtx>, wasi: Command) -> Result<(
 
 async fn run_file_seek_tell(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
     // dies when expected error doesnt happen: line 60
-    expect_fail(run_with_temp_dir(store, wasi).await)
+    run_with_temp_dir(store, wasi).await
 }
 
 async fn run_file_truncation(store: Store<WasiCtx>, wasi: Command) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -803,8 +803,6 @@ pub unsafe extern "C" fn fd_read(
     State::with(|state| {
         match state.descriptors().get(fd)? {
             Descriptor::Streams(streams) => {
-                let wasi_stream = streams.get_read_stream()?;
-
                 let blocking = if let StreamType::File(file) = &streams.type_ {
                     file.blocking
                 } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,11 +1103,10 @@ pub unsafe extern "C" fn fd_seek(
 
         // Seeking only works on files.
         if let StreamType::File(file) = &stream.type_ {
-            match file.descriptor_type {
+            if let filesystem::DescriptorType::Directory = file.descriptor_type {
                 // This isn't really the "right" errno, but it is consistient with wasmtime's
                 // preview 1 tests.
-                filesystem::DescriptorType::Directory => return Err(ERRNO_BADF),
-                _ => {}
+                return Err(ERRNO_BADF);
             }
             let from = match whence {
                 WHENCE_SET if offset >= 0 => offset,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -526,8 +526,8 @@ pub unsafe extern "C" fn fd_fdstat_get(fd: Fd, stat: *mut Fdstat) -> Errno {
 /// Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
 #[no_mangle]
 pub unsafe extern "C" fn fd_fdstat_set_flags(fd: Fd, flags: Fdflags) -> Errno {
-    // Only support changing the NONBLOCK flag.
-    if flags & !FDFLAGS_NONBLOCK != 0 {
+    // Only support changing the NONBLOCK or APPEND flags.
+    if flags & !(FDFLAGS_NONBLOCK | FDFLAGS_APPEND) != 0 {
         return wasi::ERRNO_INVAL;
     }
 
@@ -540,6 +540,7 @@ pub unsafe extern "C" fn fd_fdstat_set_flags(fd: Fd, flags: Fdflags) -> Errno {
             }) if !file.is_dir() => file,
             _ => Err(wasi::ERRNO_BADF)?,
         };
+        file.append = (flags & FDFLAGS_APPEND == FDFLAGS_APPEND);
         file.blocking = !(flags & FDFLAGS_NONBLOCK == FDFLAGS_NONBLOCK);
         Ok(())
     })


### PR DESCRIPTION
This PR fixes two bugs around seek & append behavior:
* the adapter needs to validate to make sure a seek is to a non-negative offset. Fixes `file_seek-tell` test.
* the adapter needs to set or clear the append flag in fd_fdstat_set_flags. Fixes the `fd_flags_set` test.

Plus a little bit of code motion, and commenting the fd_flags_set test better.
