### PR TITLE
adapter poll_oneoff: when descriptors.get_*_stream(fd) fails, die with that error

### DIFF
--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -469,7 +469,7 @@ async fn run_poll_oneoff_files(store: Store<WasiCtx>, wasi: Command) -> Result<(
     // trapping upwrap in poll_oneoff in adapter.
     // maybe this is related to the "if fd isnt a stream, request a pollable which completes
     // immediately so itll immediately fail" behavior, which i think breaks internal invariant...
-    expect_fail(run_with_temp_dir(store, wasi).await)
+    run_with_temp_dir(store, wasi).await
 }
 
 async fn run_poll_oneoff_stdio(store: Store<WasiCtx>, wasi: Command) -> Result<()> {

--- a/host/tests/command.rs
+++ b/host/tests/command.rs
@@ -466,10 +466,11 @@ async fn run_path_symlink_trailing_slashes(store: Store<WasiCtx>, wasi: Command)
 }
 
 async fn run_poll_oneoff_files(store: Store<WasiCtx>, wasi: Command) -> Result<()> {
-    // trapping upwrap in poll_oneoff in adapter.
-    // maybe this is related to the "if fd isnt a stream, request a pollable which completes
-    // immediately so itll immediately fail" behavior, which i think breaks internal invariant...
-    run_with_temp_dir(store, wasi).await
+    if cfg!(windows) {
+        expect_fail(run_with_temp_dir(store, wasi).await)
+    } else {
+        run_with_temp_dir(store, wasi).await
+    }
 }
 
 async fn run_poll_oneoff_stdio(store: Store<WasiCtx>, wasi: Command) -> Result<()> {


### PR DESCRIPTION
There was a special case in poll_oneoff that put in a fake clock stream when a read/write stream for a descriptor wasn't available. The poll_oneoff_files test (in `test_fd_readwrite_invalid_fd()`) checks that poll_oneoff returns a BADF when an invalid fd is subscribed to.

I'm not sure what the special case was patching over, but this passes all of the other tests right now.

cc @sunfishcode, the special case was introduced in https://github.com/bytecodealliance/preview2-prototyping/pull/53 (https://github.com/bytecodealliance/preview2-prototyping/pull/53/commits/53492768b2fbd1999e535a5cb0b1c35d52e6bfc3)