### PR TITLE
Expand reactor tests to demonstrate reusing types from other crates

### DIFF
--- a/test-programs/reactor-tests/src/lib.rs
+++ b/test-programs/reactor-tests/src/lib.rs
@@ -31,4 +31,7 @@ impl TestReactor for T {
             Ok(())
         }
     }
+    fn pass_an_imported_record(stat: filesystem::DescriptorStat) -> String {
+        format!("{stat:?}")
+    }
 }

--- a/test-programs/reactor-tests/src/lib.rs
+++ b/test-programs/reactor-tests/src/lib.rs
@@ -22,4 +22,13 @@ impl TestReactor for T {
     fn get_strings() -> Vec<String> {
         unsafe { STATE.clone() }
     }
+
+    fn write_strings_to(o: OutputStream) -> Result<(), ()> {
+        unsafe {
+            for s in STATE.iter() {
+                streams::write(o, s.as_bytes()).map_err(|_| ())?;
+            }
+            Ok(())
+        }
+    }
 }

--- a/test-programs/reactor-tests/wit/test-reactor.wit
+++ b/test-programs/reactor-tests/wit/test-reactor.wit
@@ -8,4 +8,8 @@ default world test-reactor {
 
   export add-strings: func(s: list<string>) -> u32
   export get-strings: func() -> list<string>
+
+  use io.streams.{output-stream}
+
+  export write-strings-to: func(o: output-stream) -> result
 }

--- a/test-programs/reactor-tests/wit/test-reactor.wit
+++ b/test-programs/reactor-tests/wit/test-reactor.wit
@@ -12,4 +12,7 @@ default world test-reactor {
   use io.streams.{output-stream}
 
   export write-strings-to: func(o: output-stream) -> result
+
+  use filesystem.filesystem.{descriptor-stat}
+  export pass-an-imported-record: func(d: descriptor-stat) -> string
 }

--- a/wasi-common/src/ctx.rs
+++ b/wasi-common/src/ctx.rs
@@ -83,6 +83,14 @@ impl WasiCtx {
         self.table_mut().push(Box::new(dir))
     }
 
+    pub fn push_input_stream(&mut self, i: Box<dyn InputStream>) -> Result<u32, Error> {
+        self.table_mut().push(Box::new(i))
+    }
+
+    pub fn push_output_stream(&mut self, o: Box<dyn OutputStream>) -> Result<u32, Error> {
+        self.table_mut().push(Box::new(o))
+    }
+
     /// Add network addresses to the pool.
     pub fn insert_addr<A: cap_std::net::ToSocketAddrs>(&mut self, addrs: A) -> std::io::Result<()> {
         self.pool.insert(addrs, ambient_authority())


### PR DESCRIPTION
* add a new export func showing use of output-stream, whose implementations are defined in `host` and `wasi-common`. this one works because we are using `host::wasi::streams::add_to_linker(...)`.
* add a new export func showing passing filesystem's descriptor-stat. by using bindgen's `with` syntax, we get to use the definition of this struct & its children from `host::wasi`, rather than a locally created definition.