### PR TITLE
wasi-preview2-prototype: set crate license to bytecode alliance standard

### DIFF
--- a/wasi/Cargo.toml
+++ b/wasi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 # version = "0.12.0+wasi-snapshot-preview2"
 description = "Experimental WASI Preview2 API bindings for Rust"
 edition.workspace = true
-publish = true
+license = "Apache-2.0 WITH LLVM-exception"
 
 [dependencies]
 wit-bindgen = { workspace = true, features = ["macros", "realloc"] }


### PR DESCRIPTION
required to publish to crates.io, with this commit `cargo publish --dry-run` succeeds. also, publish=true is implied, so we can drop that.