### PR TITLE
wasi-common: Table operations return a distinct TableError enum

### DIFF
--- a/wasi-common/src/dir.rs
+++ b/wasi-common/src/dir.rs
@@ -1,5 +1,5 @@
 use crate::file::{FdFlags, FileType, Filestat, OFlags, ReadOnlyFile, WasiFile};
-use crate::{Error, ErrorExt, SystemTimeSpec};
+use crate::{Error, ErrorExt, SystemTimeSpec, TableError};
 use std::any::Any;
 use std::path::PathBuf;
 
@@ -104,11 +104,11 @@ pub trait WasiDir: Send + Sync {
 }
 
 pub trait TableDirExt {
-    fn get_dir(&self, fd: u32) -> Result<&Box<dyn WasiDir>, Error>;
+    fn get_dir(&self, fd: u32) -> Result<&Box<dyn WasiDir>, TableError>;
 }
 
 impl TableDirExt for crate::table::Table {
-    fn get_dir(&self, fd: u32) -> Result<&Box<dyn WasiDir>, Error> {
+    fn get_dir(&self, fd: u32) -> Result<&Box<dyn WasiDir>, TableError> {
         self.get(fd)
     }
 }

--- a/wasi-common/src/file.rs
+++ b/wasi-common/src/file.rs
@@ -1,4 +1,4 @@
-use crate::{Error, ErrorExt, InputStream, OutputStream, SystemTimeSpec};
+use crate::{Error, ErrorExt, InputStream, OutputStream, SystemTimeSpec, TableError};
 use bitflags::bitflags;
 use std::any::Any;
 use std::io;
@@ -163,14 +163,14 @@ pub struct Filestat {
 }
 
 pub trait TableFileExt {
-    fn get_file(&self, fd: u32) -> Result<&dyn WasiFile, Error>;
-    fn get_file_mut(&mut self, fd: u32) -> Result<&mut Box<dyn WasiFile>, Error>;
+    fn get_file(&self, fd: u32) -> Result<&dyn WasiFile, TableError>;
+    fn get_file_mut(&mut self, fd: u32) -> Result<&mut Box<dyn WasiFile>, TableError>;
 }
 impl TableFileExt for crate::table::Table {
-    fn get_file(&self, fd: u32) -> Result<&dyn WasiFile, Error> {
+    fn get_file(&self, fd: u32) -> Result<&dyn WasiFile, TableError> {
         self.get::<Box<dyn WasiFile>>(fd).map(|f| f.as_ref())
     }
-    fn get_file_mut(&mut self, fd: u32) -> Result<&mut Box<dyn WasiFile>, Error> {
+    fn get_file_mut(&mut self, fd: u32) -> Result<&mut Box<dyn WasiFile>, TableError> {
         self.get_mut::<Box<dyn WasiFile>>(fd)
     }
 }

--- a/wasi-common/src/lib.rs
+++ b/wasi-common/src/lib.rs
@@ -73,4 +73,4 @@ pub use error::{Errno, Error, ErrorExt, I32Exit};
 pub use file::WasiFile;
 pub use sched::{Poll, WasiSched};
 pub use stream::{InputStream, OutputStream};
-pub use table::Table;
+pub use table::{Table, TableError};

--- a/wasi-common/src/preview2/filesystem.rs
+++ b/wasi-common/src/preview2/filesystem.rs
@@ -75,6 +75,17 @@ impl From<crate::Error> for wasi::filesystem::Error {
     }
 }
 
+impl From<crate::TableError> for wasi::filesystem::Error {
+    fn from(error: crate::TableError) -> wasi::filesystem::Error {
+        match error {
+            crate::TableError::Full => wasi::filesystem::Error::trap(anyhow!(error)),
+            crate::TableError::NotPresent | crate::TableError::WrongType => {
+                wasi::filesystem::ErrorCode::BadDescriptor.into()
+            }
+        }
+    }
+}
+
 impl From<wasi::filesystem::OpenFlags> for crate::file::OFlags {
     fn from(oflags: wasi::filesystem::OpenFlags) -> Self {
         let mut flags = crate::file::OFlags::empty();

--- a/wasi-common/src/preview2/io.rs
+++ b/wasi-common/src/preview2/io.rs
@@ -17,6 +17,18 @@ impl From<crate::Error> for streams::Error {
     }
 }
 
+impl From<crate::TableError> for streams::Error {
+    fn from(error: crate::TableError) -> streams::Error {
+        match error {
+            crate::TableError::Full => streams::Error::trap(anyhow!(error)),
+            crate::TableError::NotPresent | crate::TableError::WrongType => {
+                // wit definition needs to define a badf-equiv variant:
+                streams::StreamError {}.into()
+            }
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl<T: WasiView> streams::Host for T {
     async fn drop_input_stream(&mut self, stream: InputStream) -> anyhow::Result<()> {

--- a/wasi-common/src/stream.rs
+++ b/wasi-common/src/stream.rs
@@ -1,4 +1,4 @@
-use crate::{Error, ErrorExt};
+use crate::{Error, ErrorExt, TableError};
 use std::any::Any;
 
 /// An input bytestream.
@@ -155,24 +155,24 @@ pub trait OutputStream: Send + Sync {
 }
 
 pub trait TableStreamExt {
-    fn get_input_stream(&self, fd: u32) -> Result<&dyn InputStream, Error>;
-    fn get_input_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn InputStream>, Error>;
+    fn get_input_stream(&self, fd: u32) -> Result<&dyn InputStream, TableError>;
+    fn get_input_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn InputStream>, TableError>;
 
-    fn get_output_stream(&self, fd: u32) -> Result<&dyn OutputStream, Error>;
-    fn get_output_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn OutputStream>, Error>;
+    fn get_output_stream(&self, fd: u32) -> Result<&dyn OutputStream, TableError>;
+    fn get_output_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn OutputStream>, TableError>;
 }
 impl TableStreamExt for crate::table::Table {
-    fn get_input_stream(&self, fd: u32) -> Result<&dyn InputStream, Error> {
+    fn get_input_stream(&self, fd: u32) -> Result<&dyn InputStream, TableError> {
         self.get::<Box<dyn InputStream>>(fd).map(|f| f.as_ref())
     }
-    fn get_input_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn InputStream>, Error> {
+    fn get_input_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn InputStream>, TableError> {
         self.get_mut::<Box<dyn InputStream>>(fd)
     }
 
-    fn get_output_stream(&self, fd: u32) -> Result<&dyn OutputStream, Error> {
+    fn get_output_stream(&self, fd: u32) -> Result<&dyn OutputStream, TableError> {
         self.get::<Box<dyn OutputStream>>(fd).map(|f| f.as_ref())
     }
-    fn get_output_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn OutputStream>, Error> {
+    fn get_output_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn OutputStream>, TableError> {
         self.get_mut::<Box<dyn OutputStream>>(fd)
     }
 }

--- a/wasi-sockets/src/network_impl.rs
+++ b/wasi-sockets/src/network_impl.rs
@@ -5,10 +5,6 @@ use crate::{
 };
 use cap_std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
-pub(crate) fn convert(_error: wasi_common::Error) -> anyhow::Error {
-    todo!("convert wasi-common Error to wasi_network::Error")
-}
-
 #[async_trait::async_trait]
 impl<T: WasiSocketsView> network::Host for T {
     async fn drop_network(&mut self, this: Network) -> anyhow::Result<()> {
@@ -26,7 +22,7 @@ impl<T: WasiSocketsView> instance_network::Host for T {
         let ctx = self.ctx();
         let network = (ctx.network_creator)(ctx.pool.clone())?;
         let table = self.table_mut();
-        let network = table.push(Box::new(network)).map_err(convert)?;
+        let network = table.push(Box::new(network))?;
         Ok(network)
     }
 }

--- a/wasi-sockets/src/tcp.rs
+++ b/wasi-sockets/src/tcp.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     network::TableNetworkExt,
-    network_impl::convert,
     tcp_socket::TableTcpSocketExt,
     wasi::network::{
         Error, IpAddressFamily, Ipv4Address, Ipv4SocketAddress, Ipv6Address, Ipv6SocketAddress,
@@ -44,9 +43,9 @@ impl<T: WasiSocketsView> tcp::Host for T {
 
         let (connection, input_stream, output_stream, _addr) = socket.accept(false).await?;
 
-        let connection = table.push(Box::new(connection)).map_err(convert)?;
-        let input_stream = table.push(Box::new(input_stream)).map_err(convert)?;
-        let output_stream = table.push(Box::new(output_stream)).map_err(convert)?;
+        let connection = table.push(Box::new(connection))?;
+        let input_stream = table.push(Box::new(input_stream))?;
+        let output_stream = table.push(Box::new(output_stream))?;
 
         Ok(Ok((connection, input_stream, output_stream)))
     }
@@ -63,8 +62,8 @@ impl<T: WasiSocketsView> tcp::Host for T {
 
         let (input_stream, output_stream) = socket.connect(network, remote_address.into()).await?;
 
-        let input_stream = table.push(Box::new(input_stream)).map_err(convert)?;
-        let output_stream = table.push(Box::new(output_stream)).map_err(convert)?;
+        let input_stream = table.push(Box::new(input_stream))?;
+        let output_stream = table.push(Box::new(output_stream))?;
 
         Ok(Ok((input_stream, output_stream)))
     }
@@ -277,7 +276,7 @@ impl<T: WasiSocketsView> tcp_create_socket::Host for T {
         let ctx = self.ctx();
         let socket = (ctx.tcp_socket_creator)(address_family.into())?;
         let table = self.table_mut();
-        let socket = table.push(Box::new(socket)).map_err(convert)?;
+        let socket = table.push(Box::new(socket))?;
         Ok(Ok(socket))
     }
 }


### PR DESCRIPTION
The `wasi-common::Error` enum is actually specific to the filesystem. Table operations (which get used by other crates now) have only three error cases:
* the table is full
* the element is not present
* the element is present with another type

This change makes it possible for these error cases to be translated to whatever error value or trap is appropriate at the use site.

In wasi-common filesystem, I provided the old translation - trap when full, badf otherwise.

In wasi-common streams, we trap when full, and return the empty stream error type otherwise. That type still needs fleshing out in the wit definition.

In wasi-sockets, we always trap, because the error cases there are also not fleshed out, and also trappable errors are broken in sockets (see #163 )