### PR TITLE
build: manage toolchain via `rust-toolchain.toml`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update stable && rustup default stable
-    - run: rustup component add rustfmt
     - run: cargo fmt --all -- --check
 
   test:
@@ -38,15 +36,6 @@ jobs:
             os: macos-latest
     steps:
     - uses: actions/checkout@v3
-      # TODO: Remove +nightly once lambda-fairy/rust-errno#66 is released and
-      # rust-lang/rust#105395 reaches stable.
-      # TODO: Remove pin to 2023-03-14 once rust-lang/rust#109199 is released.
-      # TODO: Also remove it in test-programs/macros/build.rs
-    - run: rustup update nightly-2023-03-14
-    - run: rustup default nightly-2023-03-14
-    - run: rustup target add --toolchain=stable wasm32-wasi wasm32-unknown-unknown
-    - run: rustup target add --toolchain=nightly-2023-03-14 wasm32-wasi wasm32-unknown-unknown
-
       # Debug build, default features (reactor)
     - run: cargo build --target wasm32-unknown-unknown
     - run: cargo run -p verify -- ./target/wasm32-unknown-unknown/debug/wasi_snapshot_preview1.wasm
@@ -73,9 +62,6 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update stable && rustup default stable
-    - run: rustup target add wasm32-wasi wasm32-unknown-unknown
-
     - name: ensure `./wasi/wit/deps` are in sync
       run: |
         cd wasi

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+[toolchain]
+# TODO: Remove pin to 2023-03-14 once rust-lang/rust#109199 is released.
+channel = "nightly-2023-03-14" # wasi-tests and command-tests require nightly for a feature in the `io-extras` crate
+components = ["clippy", "rustfmt"]
+targets = [
+    "wasm32-unknown-unknown",
+    "wasm32-wasi"
+]

--- a/test-programs/build.rs
+++ b/test-programs/build.rs
@@ -43,12 +43,8 @@ fn main() {
     println!("cargo:rerun-if-changed=./command-tests");
     println!("cargo:rerun-if-changed=./reactor-tests");
 
-    // wasi-tests and command-tests need require nightly for a feature in the `io-extras` crate:
-    let mut cmd = Command::new("rustup");
-    cmd.arg("run")
-        .arg("nightly-2023-03-14")
-        .arg("cargo")
-        .arg("build")
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
         .arg("--target=wasm32-wasi")
         .arg("--package=wasi-tests")
         .arg("--package=command-tests")
@@ -58,12 +54,8 @@ fn main() {
     let status = cmd.status().unwrap();
     assert!(status.success());
 
-    // reactor-tests can build on stable:
-    let mut cmd = Command::new("rustup");
-    cmd.arg("run")
-        .arg("stable")
-        .arg("cargo")
-        .arg("build")
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
         .arg("--target=wasm32-wasi")
         .arg("--package=reactor-tests")
         .env("CARGO_TARGET_DIR", &out_dir)


### PR DESCRIPTION
This ensures that:
- All targets and components required are always available both in local dev environments and CI
- There's only a single toolchain used for everything
- Rustup is not a dependency for development
- There's just a single place where the Rust toolchain version and component sets are maintained