### PR TITLE
fix(wasi): assign well-known FDs to stdio

### DIFF
--- a/wasi-common/src/ctx.rs
+++ b/wasi-common/src/ctx.rs
@@ -106,14 +106,14 @@ impl WasiCtxBuilder {
     pub fn build(self, table: &mut Table) -> Result<WasiCtx, anyhow::Error> {
         use anyhow::Context;
 
-        let stdin = table
-            .push_input_stream(self.stdin.context("required member stdin")?)
+        table
+            .set_stdin(self.stdin.context("required member stdin")?)
             .context("stdin")?;
-        let stdout = table
-            .push_output_stream(self.stdout.context("required member stdout")?)
+        table
+            .set_stdout(self.stdout.context("required member stdout")?)
             .context("stdout")?;
-        let stderr = table
-            .push_output_stream(self.stderr.context("required member stderr")?)
+        table
+            .set_stderr(self.stderr.context("required member stderr")?)
             .context("stderr")?;
 
         let mut preopens = Vec::new();
@@ -131,9 +131,9 @@ impl WasiCtxBuilder {
             env: self.env,
             args: self.args,
             preopens,
-            stdin,
-            stdout,
-            stderr,
+            stdin: 0,
+            stdout: 1,
+            stderr: 2,
         })
     }
 }

--- a/wasi-common/src/stream.rs
+++ b/wasi-common/src/stream.rs
@@ -156,6 +156,10 @@ pub trait OutputStream: Send + Sync {
 }
 
 pub trait TableStreamExt {
+    fn set_stdin(&mut self, stdin: Box<dyn crate::InputStream>) -> Result<(), TableError>;
+    fn set_stdout(&mut self, stdout: Box<dyn crate::OutputStream>) -> Result<(), TableError>;
+    fn set_stderr(&mut self, stderr: Box<dyn crate::OutputStream>) -> Result<(), TableError>;
+
     fn push_input_stream(&mut self, istream: Box<dyn InputStream>) -> Result<u32, TableError>;
     fn get_input_stream(&self, fd: u32) -> Result<&dyn InputStream, TableError>;
     fn get_input_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn InputStream>, TableError>;
@@ -165,6 +169,18 @@ pub trait TableStreamExt {
     fn get_output_stream_mut(&mut self, fd: u32) -> Result<&mut Box<dyn OutputStream>, TableError>;
 }
 impl TableStreamExt for crate::Table {
+    fn set_stdin(&mut self, stdin: Box<dyn crate::InputStream>) -> Result<(), TableError> {
+        self.insert(0, Box::new(stdin)).map(|_| ())
+    }
+
+    fn set_stdout(&mut self, stdout: Box<dyn crate::OutputStream>) -> Result<(), TableError> {
+        self.insert(1, Box::new(stdout)).map(|_| ())
+    }
+
+    fn set_stderr(&mut self, stderr: Box<dyn crate::OutputStream>) -> Result<(), TableError> {
+        self.insert(2, Box::new(stderr)).map(|_| ())
+    }
+
     fn push_input_stream(
         &mut self,
         istream: Box<dyn crate::InputStream>,

--- a/wasi-common/src/table.rs
+++ b/wasi-common/src/table.rs
@@ -18,6 +18,7 @@ pub enum TableError {
 ///
 /// The `Table` type is intended to model how the Interface Types concept of Resources is shaping
 /// up. Right now it is just an approximation.
+#[derive(Debug)]
 pub struct Table {
     map: HashMap<u32, Box<dyn Any + Send + Sync>>,
     next_key: u32,

--- a/wasi-common/src/table.rs
+++ b/wasi-common/src/table.rs
@@ -50,6 +50,16 @@ impl Table {
         }
     }
 
+    /// Insert a resource at the selected index, if a resource was already present under the key,
+    /// it is returned.
+    pub fn insert(
+        &mut self,
+        key: u32,
+        a: Box<dyn Any + Send + Sync>,
+    ) -> Result<Option<Box<dyn Any + Send + Sync>>, TableError> {
+        Ok(self.map.insert(key, a))
+    }
+
     /// Check if the table has a resource at the given index.
     pub fn contains_key(&self, key: u32) -> bool {
         self.map.contains_key(&key)


### PR DESCRIPTION
In current implementation FDs `0`, `1` and `2` are never actually assigned, instead, stdio is inserted at indexes `3`, `4`, `5`.
This is PR is a fix, which ensures stdio is accessible under indexes implementations would expect